### PR TITLE
Redact auth headers and document JWT env vars

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,6 @@
 PORT=3000
 NODE_ENV=development
-DATABASE_URL=postgresql://postgres:postgres@db:5432/spa_ecommerce
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/spa_ecommerce?schema=public"
 CORS_ORIGIN=http://localhost:9000
+JWT_SECRET=change-me
+JWT_EXPIRES_IN=7d

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -30,6 +30,7 @@ export function createApp(prisma: PrismaClient) {
     (pinoHttp as unknown as (opts?: Options) => express.RequestHandler)({
       genReqId: () => randomUUID(),
       autoLogging: true,
+      redact: ['req.headers.authorization'],
       transport:
         process.env.NODE_ENV === 'production'
           ? undefined


### PR DESCRIPTION
## Summary
- safeguard JWTs by redacting `authorization` header in pino-http logs
- document `JWT_SECRET` and `JWT_EXPIRES_IN` in `.env.example`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac98a9df48832584d7a9408380e157