### PR TITLE
feat: add cart store and page

### DIFF
--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -1,0 +1,62 @@
+<template>
+  <q-page class="q-pa-md">
+    <div v-if="cart.length === 0" class="text-center q-mt-lg">
+      Tu carrito está vacío.
+    </div>
+    <div v-else class="column q-gutter-y-md">
+      <div
+        v-for="line in cart"
+        :key="line.lineId"
+        class="row items-center q-gutter-x-md"
+      >
+        <img :src="line.image_url" alt="" class="cart-image" />
+        <div class="col">
+          <div class="text-weight-medium">{{ line.name }}</div>
+          <div>{{ (line.price_cents / 100).toFixed(2) }} {{ line.currency }}</div>
+        </div>
+        <q-input
+          type="number"
+          :model-value="line.qty"
+          min="1"
+          :max="line.stock"
+          style="width: 80px"
+          @update:model-value="(val) => cartStore.updateQty(line.lineId, Number(val))"
+        />
+        <q-btn
+          dense
+          flat
+          icon="delete"
+          color="negative"
+          @click="cartStore.remove(line.lineId)"
+        />
+      </div>
+      <div class="text-right q-mt-lg">
+        <div>
+          Subtotal: {{ (subtotal / 100).toFixed(2) }} {{ currency }}
+        </div>
+        <div>
+          Total: {{ (total / 100).toFixed(2) }} {{ currency }}
+        </div>
+      </div>
+    </div>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useCartStore } from 'stores/cartStore';
+
+const cartStore = useCartStore();
+const cart = computed(() => cartStore.cart);
+const subtotal = computed(() => cartStore.subtotal);
+const total = computed(() => cartStore.total);
+const currency = computed(() => cart.value[0]?.currency || 'USD');
+</script>
+
+<style scoped>
+.cart-image {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+}
+</style>

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -8,6 +8,7 @@ const routes: RouteRecordRaw[] = [
       { path: '', component: () => import('pages/IndexPage.vue') },
       { path: 'login', component: () => import('pages/LoginPage.vue') },
       { path: 'register', component: () => import('pages/RegisterPage.vue') },
+      { path: 'cart', component: () => import('pages/CartPage.vue') },
     ],
   },
 

--- a/frontend/src/stores/cartStore.js
+++ b/frontend/src/stores/cartStore.js
@@ -1,0 +1,85 @@
+import { defineStore } from 'pinia';
+import { useQuasar } from 'quasar';
+import { useAuthStore } from './auth';
+
+const STORAGE_KEY = 'cart';
+
+export const useCartStore = defineStore('cart', {
+  state: () => ({
+    cart: JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]'),
+  }),
+  getters: {
+    subtotal: (state) =>
+      state.cart.reduce(
+        (sum, line) => sum + line.price_cents * line.qty,
+        0
+      ),
+    total() {
+      return this.subtotal;
+    },
+  },
+  actions: {
+    persist() {
+      const auth = useAuthStore();
+      if (!auth.isAuthenticated) {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(this.cart));
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+        // TODO: sync with /cart endpoint when backend ready
+      }
+    },
+    add(product, qty = 1) {
+      const $q = useQuasar();
+      const existing = this.cart.find((l) => l.productId === product.id);
+      const targetQty = existing ? existing.qty + qty : qty;
+      const stock = existing ? existing.stock : product.stock;
+      if (targetQty > stock) {
+        $q.notify({ type: 'negative', message: 'No hay suficiente stock' });
+        return;
+      }
+      if (existing) {
+        existing.qty += qty;
+      } else {
+        this.cart.push({
+          lineId: Date.now().toString(),
+          productId: product.id,
+          name: product.name,
+          slug: product.slug,
+          price_cents: product.price_cents,
+          currency: product.currency,
+          qty,
+          stock: product.stock,
+          image_url: product.image_url,
+        });
+      }
+      this.persist();
+      $q.notify({ type: 'positive', message: 'Producto añadido al carrito' });
+    },
+    updateQty(lineId, qty) {
+      const $q = useQuasar();
+      const line = this.cart.find((l) => l.lineId === lineId);
+      if (!line) return;
+      if (qty < 1) {
+        $q.notify({ type: 'negative', message: 'La cantidad mínima es 1' });
+        return;
+      }
+      if (qty > line.stock) {
+        $q.notify({
+          type: 'negative',
+          message: `Solo hay ${line.stock} unidades disponibles`,
+        });
+        return;
+      }
+      line.qty = qty;
+      this.persist();
+      $q.notify({ type: 'positive', message: 'Cantidad actualizada' });
+    },
+    remove(lineId) {
+      const $q = useQuasar();
+      this.cart = this.cart.filter((l) => l.lineId !== lineId);
+      this.persist();
+      $q.notify({ type: 'positive', message: 'Producto eliminado del carrito' });
+    },
+  },
+});
+


### PR DESCRIPTION
## Summary
- implement Pinia cart store with add, update, remove and persistence
- add editable CartPage with totals and notifications
- expose cart page via router

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca8c5bda88325ab4da3f673bde9d4