### PR TITLE
feat(frontend): add product search filters

### DIFF
--- a/frontend/src/components/ProductSearch.vue
+++ b/frontend/src/components/ProductSearch.vue
@@ -1,0 +1,53 @@
+<template>
+  <div class="row q-col-gutter-md items-start">
+    <div class="col">
+      <q-input
+        v-model="text"
+        debounce="300"
+        placeholder="Buscar productos"
+        dense
+      >
+        <template #append>
+          <q-icon name="search" />
+        </template>
+      </q-input>
+    </div>
+    <div class="col-12 col-sm-4" v-if="categories && categories.length">
+      <q-select
+        v-model="category"
+        :options="categories"
+        option-label="label"
+        option-value="value"
+        emit-value
+        map-options
+        label="Categoría"
+        dense
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { useProductsStore } from 'src/stores/productsStore';
+
+interface CategoryOption {
+  label: string;
+  value: string;
+}
+
+interface Props {
+  categories?: CategoryOption[];
+}
+
+defineProps<Props>();
+
+const store = useProductsStore();
+
+const text = ref(store.filters.text);
+const category = ref(store.filters.category);
+
+watch([text, category], () => {
+  store.setFilters({ text: text.value, category: category.value });
+});
+</script>

--- a/frontend/src/stores/productsStore.ts
+++ b/frontend/src/stores/productsStore.ts
@@ -10,11 +10,17 @@ export interface Product {
   image_url?: string;
 }
 
+interface Filters {
+  text: string;
+  category: string;
+}
+
 interface ProductsState {
   pages: Record<number, Product[]>;
   total: number;
   loading: boolean;
   error: string | null;
+  filters: Filters;
 }
 
 export const useProductsStore = defineStore('products', {
@@ -23,16 +29,27 @@ export const useProductsStore = defineStore('products', {
     total: 0,
     loading: false,
     error: null,
+    filters: {
+      text: '',
+      category: '',
+    },
   }),
   getters: {
     getProducts: (state) => (page: number) => state.pages[page] ?? [],
     totalPages: (state) => (limit: number) => Math.ceil(state.total / limit),
   },
   actions: {
+    setFilters(newFilters: Partial<Filters>) {
+      this.filters = { ...this.filters, ...newFilters };
+      this.pages = {};
+      this.total = 0;
+      void this.fetchProducts(1);
+    },
     async fetchProducts(
       page = 1,
       limit = 12,
-      opts: { force?: boolean; prefetch?: boolean } = {}
+      filters: Filters = this.filters,
+      opts: { force?: boolean; prefetch?: boolean } = {},
     ) {
       const { force = false, prefetch = false } = opts;
       if (this.pages[page] && !force) {
@@ -43,7 +60,13 @@ export const useProductsStore = defineStore('products', {
         this.error = null;
       }
       try {
-        const res = await fetch(`/products?page=${page}&limit=${limit}`);
+        const params = new URLSearchParams({
+          page: page.toString(),
+          limit: limit.toString(),
+        });
+        if (filters.text) params.append('text', filters.text);
+        if (filters.category) params.append('category', filters.category);
+        const res = await fetch(`/products?${params.toString()}`);
         if (!res.ok) throw new Error('Failed to fetch products');
         const json = await res.json();
         this.pages[page] = json.data as Product[];
@@ -60,4 +83,3 @@ export const useProductsStore = defineStore('products', {
     },
   },
 });
-


### PR DESCRIPTION
## Summary
- add `ProductSearch` component with debounced text input and optional category filter
- persist text and category filters in Pinia store and apply them when fetching products

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68acab907f38832582062e0b4ebcef24