### PR TITLE
feat: add checkout order creation

### DIFF
--- a/backend/prisma/migrations/20251201000000_orders/migration.sql
+++ b/backend/prisma/migrations/20251201000000_orders/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "public"."Order" (
+    "id" SERIAL NOT NULL,
+    "status" TEXT NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'MXN',
+    "total_cents" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."OrderItem" (
+    "id" SERIAL NOT NULL,
+    "orderId" INTEGER NOT NULL,
+    "productId" INTEGER NOT NULL,
+    "qty" INTEGER NOT NULL,
+    "unit_price_cents" INTEGER NOT NULL,
+    CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "public"."Order"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "OrderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "public"."Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -35,5 +35,27 @@ model Product {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
+  order_items OrderItem[]
+
   @@index([is_active])
+}
+
+model Order {
+  id          Int        @id @default(autoincrement())
+  status      String
+  currency    String     @default("MXN")
+  total_cents Int
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+  items       OrderItem[]
+}
+
+model OrderItem {
+  id               Int     @id @default(autoincrement())
+  order            Order   @relation(fields: [orderId], references: [id])
+  orderId          Int
+  product          Product @relation(fields: [productId], references: [id])
+  productId        Int
+  qty              Int
+  unit_price_cents Int
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,8 @@ import type { PrismaClient } from '@prisma/client';
 import { createAuthRouter } from './routes/auth.js';
 // eslint-disable-next-line import/no-unresolved
 import { createProductsRouter } from './routes/products.js';
+// eslint-disable-next-line import/no-unresolved
+import { createCheckoutRouter } from './routes/checkout.js';
 
 interface RequestWithLog extends express.Request {
   log?: Logger;
@@ -67,6 +69,7 @@ export function createApp(prisma: PrismaClient) {
 
   app.use('/auth', createAuthRouter(prisma));
   app.use('/products', createProductsRouter(prisma));
+  app.use('/checkout', createCheckoutRouter(prisma));
 
   app.get('/api/users', async (req, res, next) => {
     try {

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import { z } from 'zod';
+import type { PrismaClient } from '@prisma/client';
+
+const createOrderSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        productId: z.number().int().positive(),
+        qty: z.number().int().positive(),
+      })
+    )
+    .min(1),
+});
+
+export function createCheckoutRouter(prisma: PrismaClient) {
+  const router = express.Router();
+
+  router.post('/create-order', async (req, res, next) => {
+    const parsed = createOrderSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: parsed.error.flatten() });
+    }
+
+    const { items } = parsed.data;
+    try {
+      const ids = items.map((i) => i.productId);
+      const products = await prisma.product.findMany({
+        where: { id: { in: ids } },
+      });
+      if (products.length !== ids.length) {
+        return res.status(400).json({ error: 'Invalid product' });
+      }
+
+      const productMap = new Map(products.map((p) => [p.id, p]));
+      for (const item of items) {
+        const product = productMap.get(item.productId);
+        if (!product || item.qty > product.stock) {
+          return res.status(400).json({ error: 'Insufficient stock' });
+        }
+      }
+
+      const total = items.reduce((sum, item) => {
+        const product = productMap.get(item.productId)!;
+        return sum + item.qty * product.price_cents;
+      }, 0);
+
+      const order = await prisma.order.create({
+        data: {
+          status: 'PENDING',
+          currency: 'MXN',
+          total_cents: total,
+          items: {
+            create: items.map((item) => {
+              const product = productMap.get(item.productId)!;
+              return {
+                productId: item.productId,
+                qty: item.qty,
+                unit_price_cents: product.price_cents,
+              };
+            }),
+          },
+        },
+      });
+
+      res.json({ orderId: order.id, total_cents: order.total_cents });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/backend/test/checkout.integration.test.ts
+++ b/backend/test/checkout.integration.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import type { PrismaClient } from '@prisma/client';
+
+let createApp: typeof import('../src/app.js').createApp;
+
+process.env.JWT_SECRET = 'testsecret';
+
+interface Product {
+  id: number;
+  price_cents: number;
+  stock: number;
+}
+
+class FakePrisma {
+  products: Product[] = [
+    { id: 1, price_cents: 10000, stock: 3 },
+    { id: 5, price_cents: 59900, stock: 1 },
+  ];
+
+  createdOrder: any = null;
+
+  product = {
+    findMany: async ({ where }: any) => {
+      const ids: number[] = where.id.in;
+      return this.products.filter((p) => ids.includes(p.id));
+    },
+  };
+
+  order = {
+    create: async ({ data }: any) => {
+      this.createdOrder = data;
+      return { id: 123, ...data };
+    },
+  };
+}
+
+let prisma: FakePrisma;
+let app: ReturnType<typeof createApp>;
+
+beforeAll(async () => {
+  ({ createApp } = await import('../src/app.js'));
+});
+
+beforeEach(() => {
+  prisma = new FakePrisma();
+  app = createApp(prisma as unknown as PrismaClient);
+});
+
+describe('checkout create-order', () => {
+  it('creates an order with items and returns total', async () => {
+    const res = await request(app)
+      .post('/checkout/create-order')
+      .send({ items: [{ productId: 1, qty: 2 }, { productId: 5, qty: 1 }] })
+      .expect(200);
+
+    expect(res.body.total_cents).toBe(79900);
+    expect(prisma.createdOrder.status).toBe('PENDING');
+    expect(prisma.createdOrder.currency).toBe('MXN');
+    expect(prisma.createdOrder.total_cents).toBe(79900);
+    expect(prisma.createdOrder.items.create).toEqual([
+      { productId: 1, qty: 2, unit_price_cents: 10000 },
+      { productId: 5, qty: 1, unit_price_cents: 59900 },
+    ]);
+  });
+
+  it('fails when qty exceeds stock', async () => {
+    await request(app)
+      .post('/checkout/create-order')
+      .send({ items: [{ productId: 1, qty: 5 }] })
+      .expect(400);
+    expect(prisma.createdOrder).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `Order` and `OrderItem` models
- implement `/checkout/create-order` endpoint to create pending orders and items
- wire checkout router into app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc491dcd4832596e892d73e8799c2