### PR TITLE
feat: add MercadoPago webhook

### DIFF
--- a/backend/prisma/migrations/20251203000000_add_payment_event/migration.sql
+++ b/backend/prisma/migrations/20251203000000_add_payment_event/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "PaymentEvent" (
+  "id" SERIAL PRIMARY KEY,
+  "orderId" INTEGER NOT NULL,
+  "mp_payment_id" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "raw_payload" JSONB NOT NULL,
+  "processed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PaymentEvent_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "PaymentEvent_mp_payment_id_key" ON "PaymentEvent"("mp_payment_id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,6 +49,7 @@ model Order {
   updatedAt   DateTime   @updatedAt
   mp_preference_id String?
   items       OrderItem[]
+  paymentEvents PaymentEvent[]
 }
 
 model OrderItem {
@@ -59,4 +60,14 @@ model OrderItem {
   productId        Int
   qty              Int
   unit_price_cents Int
+}
+
+model PaymentEvent {
+  id            Int      @id @default(autoincrement())
+  order         Order    @relation(fields: [orderId], references: [id])
+  orderId       Int
+  mp_payment_id String   @unique
+  status        String
+  raw_payload   Json
+  processed_at  DateTime @default(now())
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,8 @@ import { createAuthRouter } from './routes/auth.js';
 import { createProductsRouter } from './routes/products.js';
 // eslint-disable-next-line import/no-unresolved
 import { createCheckoutRouter } from './routes/checkout.js';
+// eslint-disable-next-line import/no-unresolved
+import { createWebhookRouter } from './routes/webhook.js';
 
 interface RequestWithLog extends express.Request {
   log?: Logger;
@@ -70,6 +72,7 @@ export function createApp(prisma: PrismaClient) {
   app.use('/auth', createAuthRouter(prisma));
   app.use('/products', createProductsRouter(prisma));
   app.use('/checkout', createCheckoutRouter(prisma));
+  app.use('/webhook', createWebhookRouter(prisma));
 
   app.get('/api/users', async (req, res, next) => {
     try {

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -103,6 +103,7 @@ export function createCheckoutRouter(prisma: PrismaClient) {
           pending: `${process.env.CORS_ORIGIN}/checkout/pending`,
         },
         auto_return: 'approved',
+        external_reference: orderId.toString(),
       });
 
       await prisma.order.update({

--- a/backend/src/routes/webhook.ts
+++ b/backend/src/routes/webhook.ts
@@ -1,0 +1,69 @@
+import express from 'express';
+import type { PrismaClient, Prisma } from '@prisma/client';
+import { MercadoPagoConfig, Payment } from 'mercadopago';
+import type { Logger } from 'pino';
+
+interface RequestWithLog extends express.Request {
+  log?: Logger;
+}
+
+export function createWebhookRouter(prisma: PrismaClient) {
+  const router = express.Router();
+  const mp = new MercadoPagoConfig({ accessToken: process.env.MP_ACCESS_TOKEN || '' });
+
+  router.post('/mercadopago', async (req: RequestWithLog, res) => {
+    const mpPaymentId = req.body?.data?.id ?? req.body?.mp_payment_id ?? req.body?.id;
+    if (!mpPaymentId) {
+      req.log?.warn?.('mp_payment_id missing');
+      return res.status(400).json({ error: 'mp_payment_id missing' });
+    }
+
+    try {
+      const exists = await prisma.paymentEvent.findUnique({
+        where: { mp_payment_id: String(mpPaymentId) },
+      });
+      if (exists) {
+        req.log?.info?.({ mp_payment_id: mpPaymentId }, 'Payment already processed');
+        return res.status(200).json({ status: 'ignored' });
+      }
+
+      const payment = await new Payment(mp).get({ id: String(mpPaymentId) });
+      const orderId = Number(payment.external_reference);
+      if (!orderId || Number.isNaN(orderId)) {
+        req.log?.error?.({ mp_payment_id: mpPaymentId }, 'Order reference not found');
+        return res.status(400).json({ error: 'order not found' });
+      }
+
+      let orderStatus: string;
+      switch (payment.status) {
+        case 'approved':
+          orderStatus = 'APPROVED';
+          break;
+        case 'rejected':
+          orderStatus = 'REJECTED';
+          break;
+        default:
+          orderStatus = 'PENDING';
+      }
+
+      await prisma.$transaction([
+        prisma.order.update({ where: { id: orderId }, data: { status: orderStatus } }),
+        prisma.paymentEvent.create({
+          data: {
+            orderId,
+            mp_payment_id: String(mpPaymentId),
+            status: orderStatus,
+            raw_payload: req.body as unknown as Prisma.JsonValue,
+          },
+        }),
+      ]);
+
+      res.json({ ok: true });
+    } catch (err) {
+      req.log?.error?.(err);
+      res.status(500).json({ error: 'Internal Server Error' });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- add PaymentEvent audit table
- implement MercadoPago webhook with idempotent processing
- include order reference in preference for payment tracking

## Testing
- `npm test` *(fails: Failed to load url mercadopago)*

------
https://chatgpt.com/codex/tasks/task_e_68acd738b1288325bffaf2e0269e358f