### PR TITLE
feat(webhook): add MercadoPago IP allowlist and idempotence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,6 @@ CORS_ORIGIN=http://localhost:9000
 JWT_SECRET=change-me
 JWT_EXPIRES_IN=7d
 MP_ACCESS_TOKEN=your-token
+MP_ALLOWED_IPS=1.2.3.4,5.6.7.8
 # Frontend
 VITE_API_BASE_URL=http://localhost:3000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,4 @@ CORS_ORIGIN=http://localhost:9000
 JWT_SECRET=change-me
 JWT_EXPIRES_IN=7d
 MP_ACCESS_TOKEN=your-token
+MP_ALLOWED_IPS=1.2.3.4,5.6.7.8

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,6 +16,8 @@
 - `CORS_ORIGIN` — origen permitido para CORS (`*` por defecto)
 - `JWT_SECRET` — secreto para firmar JWT
 - `JWT_EXPIRES_IN` — expiración del token (ej. `7d`)
+- `MP_ACCESS_TOKEN` — token de acceso de MercadoPago
+- `MP_ALLOWED_IPS` — IPs permitidas para webhooks de MercadoPago (separadas por coma)
 
 ## Rutas
 

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { z } from 'zod';
+// eslint-disable-next-line import/no-unresolved
 import { MercadoPagoConfig, Preference } from 'mercadopago';
 import type { PrismaClient } from '@prisma/client';
 

--- a/backend/src/routes/webhook.ts
+++ b/backend/src/routes/webhook.ts
@@ -1,5 +1,6 @@
 import express from 'express';
-import type { PrismaClient, Prisma } from '@prisma/client';
+import { Prisma, type PrismaClient } from '@prisma/client';
+// eslint-disable-next-line import/no-unresolved
 import { MercadoPagoConfig, Payment } from 'mercadopago';
 import type { Logger } from 'pino';
 
@@ -10,8 +11,20 @@ interface RequestWithLog extends express.Request {
 export function createWebhookRouter(prisma: PrismaClient) {
   const router = express.Router();
   const mp = new MercadoPagoConfig({ accessToken: process.env.MP_ACCESS_TOKEN || '' });
+  const allowedIps = (process.env.MP_ALLOWED_IPS || '')
+    .split(',')
+    .map((ip) => ip.trim())
+    .filter(Boolean);
 
-  router.post('/mercadopago', async (req: RequestWithLog, res) => {
+  const allowlist = (req: RequestWithLog, res: express.Response, next: express.NextFunction) => {
+    if (allowedIps.length && !allowedIps.includes(req.ip)) {
+      req.log?.warn?.({ ip: req.ip }, 'MercadoPago IP not allowed');
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+
+  router.post('/mercadopago', allowlist, async (req: RequestWithLog, res) => {
     const mpPaymentId = req.body?.data?.id ?? req.body?.mp_payment_id ?? req.body?.id;
     if (!mpPaymentId) {
       req.log?.warn?.('mp_payment_id missing');
@@ -23,7 +36,7 @@ export function createWebhookRouter(prisma: PrismaClient) {
         where: { mp_payment_id: String(mpPaymentId) },
       });
       if (exists) {
-        req.log?.info?.({ mp_payment_id: mpPaymentId }, 'Payment already processed');
+        req.log?.info?.({ mp_payment_id: mpPaymentId }, 'Evento duplicado ignorado');
         return res.status(200).json({ status: 'ignored' });
       }
 
@@ -60,6 +73,10 @@ export function createWebhookRouter(prisma: PrismaClient) {
 
       res.json({ ok: true });
     } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        req.log?.info?.({ mp_payment_id: mpPaymentId }, 'Evento duplicado ignorado');
+        return res.status(200).json({ status: 'ignored' });
+      }
       req.log?.error?.(err);
       res.status(500).json({ error: 'Internal Server Error' });
     }

--- a/backend/test/auth.integration.test.ts
+++ b/backend/test/auth.integration.test.ts
@@ -1,6 +1,13 @@
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import type { PrismaClient } from '@prisma/client';
+
+vi.mock('mercadopago', () => ({
+  MercadoPagoConfig: vi.fn().mockImplementation(() => ({})),
+  Preference: vi.fn().mockImplementation(() => ({
+    create: vi.fn(),
+  })),
+}));
 
 process.env.JWT_SECRET = 'testsecret';
 process.env.JWT_EXPIRES_IN = '7d';

--- a/backend/test/products.integration.test.ts
+++ b/backend/test/products.integration.test.ts
@@ -1,8 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import type { PrismaClient } from '@prisma/client';
 
 let createApp: typeof import('../src/app.js').createApp;
+
+vi.mock('mercadopago', () => ({
+  MercadoPagoConfig: vi.fn().mockImplementation(() => ({})),
+  Preference: vi.fn().mockImplementation(() => ({
+    create: vi.fn(),
+  })),
+}));
 
 process.env.JWT_SECRET = 'testsecret';
 

--- a/backend/test/webhook.integration.test.ts
+++ b/backend/test/webhook.integration.test.ts
@@ -1,0 +1,91 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import type { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+
+let createApp: typeof import('../src/app.js').createApp;
+
+process.env.JWT_SECRET = 'testsecret';
+process.env.MP_ACCESS_TOKEN = 'test';
+process.env.MP_ALLOWED_IPS = '1.1.1.1';
+process.env.CORS_ORIGIN = 'http://localhost:9000';
+
+vi.mock('mercadopago', () => ({
+  MercadoPagoConfig: vi.fn().mockImplementation(() => ({})),
+  Payment: vi.fn().mockImplementation(() => ({
+    get: vi.fn().mockResolvedValue({
+      external_reference: '123',
+      status: 'approved',
+    }),
+  })),
+}));
+
+class FakePrisma {
+  events: any[] = [];
+
+  order = {
+    update: vi.fn().mockResolvedValue(null),
+  };
+
+  paymentEvent = {
+    findUnique: vi.fn().mockResolvedValue(null),
+    create: async ({ data }: any) => {
+      if (this.events.some((e) => e.mp_payment_id === data.mp_payment_id)) {
+        throw new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '6.14.0',
+          meta: { target: ['mp_payment_id'] },
+        });
+      }
+      this.events.push(data);
+      return data;
+    },
+  };
+
+  $transaction = async (ops: Promise<any>[]) => {
+    for (const op of ops) {
+      await op;
+    }
+  };
+}
+
+let prisma: FakePrisma;
+let app: ReturnType<typeof createApp>;
+
+beforeAll(async () => {
+  ({ createApp } = await import('../src/app.js'));
+});
+
+beforeEach(() => {
+  prisma = new FakePrisma();
+  app = createApp(prisma as unknown as PrismaClient);
+  app.set('trust proxy', 'loopback');
+});
+
+describe('MercadoPago webhook', () => {
+  it('ignores duplicate events on unique constraint error', async () => {
+    await request(app)
+      .post('/webhook/mercadopago')
+      .set('X-Forwarded-For', '1.1.1.1')
+      .send({ data: { id: 'pay123' } })
+      .expect(200);
+
+    const res = await request(app)
+      .post('/webhook/mercadopago')
+      .set('X-Forwarded-For', '1.1.1.1')
+      .send({ data: { id: 'pay123' } })
+      .expect(200);
+
+    expect(res.body.status).toBe('ignored');
+    expect(prisma.events).toHaveLength(1);
+  });
+
+  it('blocks requests from non-allowlisted IPs', async () => {
+    await request(app)
+      .post('/webhook/mercadopago')
+      .set('X-Forwarded-For', '2.2.2.2')
+      .send({ data: { id: 'pay321' } })
+      .expect(403);
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle concurrent duplicate MercadoPago events gracefully
- restrict MercadoPago webhooks to configured IP allowlist
- document new MP_ALLOWED_IPS variable and add integration tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acda27088c83258d8e82262b1be81f