### PR TITLE
fix: rejoin socket room after reconnect

### DIFF
--- a/frontend/src/boot/socket.ts
+++ b/frontend/src/boot/socket.ts
@@ -4,6 +4,7 @@ import { watch } from 'vue';
 import { useAuthStore } from 'src/stores/auth';
 
 let socket: Socket;
+let userRoom: string | null = null;
 
 export default boot(({ app }) => {
   const auth = useAuthStore();
@@ -14,21 +15,29 @@ export default boot(({ app }) => {
     reconnection: true,
   });
 
+  socket.on('connect', () => {
+    if (userRoom) {
+      socket.emit('join', userRoom);
+    }
+  });
+
   watch(
     () => auth.token,
     (token) => {
       if (token) {
         socket.auth = { token };
-        socket.connect();
         try {
           const payload = JSON.parse(atob(token.split('.')[1] || '')) as { sub?: string };
           if (payload.sub) {
-            socket.emit('join', `user:${payload.sub}`);
+            userRoom = `user:${payload.sub}`;
           }
         } catch (e) {
           console.error('Invalid token', e);
+          userRoom = null;
         }
+        socket.connect();
       } else {
+        userRoom = null;
         socket.disconnect();
       }
     },


### PR DESCRIPTION
## Summary
- re-emit room join on socket reconnects to keep order status updates coming

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace004309083258a688442e660fbc2