### PR TITLE
Harden Express security and add database backups

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,11 +13,20 @@
 ## Variables
 
 - `DATABASE_URL` — conexión a Postgres
-- `CORS_ORIGIN` — origen permitido para CORS (`*` por defecto)
+- `CORS_ORIGIN` — orígenes permitidos para CORS separados por coma (ej. `https://mi-front.com`)
 - `JWT_SECRET` — secreto para firmar JWT
 - `JWT_EXPIRES_IN` — expiración del token (ej. `7d`)
 - `MP_ACCESS_TOKEN` — token de acceso de MercadoPago
 - `MP_ALLOWED_IPS` — IPs permitidas para webhooks de MercadoPago (separadas por coma)
+
+## Seguridad
+
+- `helmet` aplicado con HSTS, XSS Filter y `noSniff`.
+- CORS restringido a los dominios definidos en `CORS_ORIGIN`.
+- Rate limiting con `express-rate-limit`:
+  - `/auth/*` → 5 solicitudes por minuto por IP.
+  - `/webhook/mercadopago` → 30 solicitudes por minuto por IP.
+- Script `scripts/db-backup.sh` para respaldos diarios de la base de datos (ejecutar vía cron).
 
 ## Rutas
 

--- a/backend/scripts/db-backup.sh
+++ b/backend/scripts/db-backup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+mkdir -p "$BACKUP_DIR"
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL is required" >&2
+  exit 1
+fi
+
+FILE="$BACKUP_DIR/$(date +%F_%H-%M-%S).sql.gz"
+pg_dump "$DATABASE_URL" | gzip > "$FILE"
+echo "Backup saved to $FILE"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,19 +24,59 @@ interface RequestWithLog extends express.Request {
 
 export function createApp(prisma: PrismaClient) {
   const app = express();
-  const CORS_ORIGIN = process.env.CORS_ORIGIN || '*';
+  const allowedOrigins = (process.env.CORS_ORIGIN || 'https://mi-front.com')
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
   const JWT_SECRET = process.env.JWT_SECRET ?? '';
 
   app.use(helmet());
-  app.use(cors({ origin: CORS_ORIGIN, credentials: true }));
+  app.use(helmet.hsts({ maxAge: 31_536_000, includeSubDomains: true, preload: true }));
+  app.use(helmet.noSniff());
+  app.use(helmet.xssFilter());
+  app.use(
+    cors({
+      origin: (origin, callback) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+          return callback(null, true);
+        }
+        return callback(new Error('Not allowed by CORS'));
+      },
+      credentials: true,
+    }),
+  );
   app.use(express.json());
-  app.use(rateLimit({ windowMs: 60_000, limit: 100 }));
+
+  const authLimiter = rateLimit({
+    windowMs: 60_000,
+    limit: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  const webhookLimiter = rateLimit({
+    windowMs: 60_000,
+    limit: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
 
   app.use(
     (pinoHttp as unknown as (opts?: Options) => express.RequestHandler)({
       genReqId: () => randomUUID(),
       autoLogging: true,
-      redact: ['req.headers.authorization'],
+      redact: {
+        paths: [
+          'req.headers.authorization',
+          'req.headers.cookie',
+          'req.body.password',
+          'req.body.token',
+          'req.body.refreshToken',
+          'req.body.cardNumber',
+          'req.body.cvv',
+        ],
+        censor: '[REDACTED]',
+      },
       transport:
         process.env.NODE_ENV === 'production'
           ? undefined
@@ -69,9 +109,10 @@ export function createApp(prisma: PrismaClient) {
     res.json({ ok: true, service: 'spa-ecommerce-backend' });
   });
 
-  app.use('/auth', createAuthRouter(prisma));
+  app.use('/auth', authLimiter, createAuthRouter(prisma));
   app.use('/products', createProductsRouter(prisma));
   app.use('/checkout', createCheckoutRouter(prisma));
+  app.use('/webhook/mercadopago', webhookLimiter);
   app.use('/webhook', createWebhookRouter(prisma));
 
   app.get('/api/users', async (req, res, next) => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+// eslint-disable-next-line import/no-unresolved
 import { Server } from 'socket.io';
 import { PrismaClient } from '@prisma/client';
 // eslint-disable-next-line import/no-unresolved

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -10,7 +10,7 @@ const createOrderSchema = z.object({
       z.object({
         productId: z.number().int().positive(),
         qty: z.number().int().positive(),
-      })
+      }),
     )
     .min(1),
 });

--- a/docs/OWASP_CHECKLIST.md
+++ b/docs/OWASP_CHECKLIST.md
@@ -1,0 +1,33 @@
+# OWASP Top 10 – Checklist Rápida
+
+- **A01 - Broken Access Control:**
+  - Uso de JWT y verificación de roles.
+- **A02 - Cryptographic Failures:**
+  - Contraseñas hasheadas con `bcryptjs`.
+  - HTTPS obligatorio y HSTS habilitado.
+- **A03 - Injection:**
+  - ORM Prisma evita SQL injection.
+  - Inputs validados con `zod`.
+- **A04 - Insecure Design:**
+  - Revisar flujos de negocio y límites de rate limit.
+- **A05 - Security Misconfiguration:**
+  - `helmet` configurado, CORS restringido, logs sanitizados.
+- **A06 - Vulnerable and Outdated Components:**
+  - Dependencias actualizadas vía `npm audit`.
+- **A07 - Identification and Authentication Failures:**
+  - Rate limit estricto en `/auth/*` y expiración de JWT.
+- **A08 - Software and Data Integrity Failures:**
+  - Validación de payloads en webhooks.
+- **A09 - Security Logging and Monitoring Failures:**
+  - `pino` con redacción de datos sensibles y recomendación de rotación.
+- **A10 - Server-Side Request Forgery:**
+  - Webhooks con allowlist de IPs.
+
+## Backups
+
+Ejecutar `backend/scripts/db-backup.sh` para generar un dump comprimido usando `pg_dump`.
+Ejemplo de cron diario a las 2 AM:
+
+```
+0 2 * * * /ruta/al/repo/backend/scripts/db-backup.sh > /var/log/db-backup.log 2>&1
+```


### PR DESCRIPTION
## Summary
- tighten HTTP security with Helmet, restrictive CORS and route‑specific rate limits
- redact sensitive fields in HTTP logs and document OWASP Top 10 checklist
- add pg_dump backup script and document security settings

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ace14d5e90832587a938b3b3ddeda9