### PR TITLE
feat: add log rotation

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -28,6 +28,12 @@
   - `/webhook/mercadopago` → 30 solicitudes por minuto por IP.
 - Script `scripts/db-backup.sh` para respaldos diarios de la base de datos (ejecutar vía cron).
 
+## Logs
+
+- Los logs se guardan en `logs/app.log`.
+- Se rotan diariamente o al alcanzar 10 MB, conservando solo los últimos 7 archivos.
+- Datos sensibles como tokens o contraseñas se redactan como `[REDACTED]`.
+
 ## Rutas
 
 - `GET /health` → `{ "ok": true, "service": "spa-ecommerce-backend" }`

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "passport-jwt": "^4.0.1",
         "pino": "^9.9.0",
         "pino-http": "^10.5.0",
+        "rotating-file-stream": "^3.2.7",
         "socket.io": "^4.7.5",
         "zod": "^3.23.8"
       },
@@ -6380,6 +6381,18 @@
         "@rollup/rollup-win32-ia32-msvc": "4.48.1",
         "@rollup/rollup-win32-x64-msvc": "4.48.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rotating-file-stream": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-3.2.7.tgz",
+      "integrity": "sha512-SVquhBEVvRFY+nWLUc791Y0MIlyZrEClRZwZFLLRgJKldHyV1z4e2e/dp9LPqCS3AM//uq/c3PnOFgjqnm5P+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "url": "https://www.blockchain.com/btc/address/12p1p5q7sK75tPyuesZmssiMYr4TKzpSCN"
       }
     },
     "node_modules/run-parallel": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "passport-jwt": "^4.0.1",
     "pino": "^9.9.0",
     "pino-http": "^10.5.0",
+    "rotating-file-stream": "^3.2.7",
     "socket.io": "^4.7.5",
     "zod": "^3.23.8"
   },

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,8 +3,10 @@ import cors from 'cors';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import pinoHttp from 'pino-http';
+import pino, { type Logger } from 'pino';
+import { createStream } from 'rotating-file-stream';
+import fs from 'fs';
 import type { Options } from 'pino-http';
-import type { Logger } from 'pino';
 import { randomUUID } from 'crypto';
 import passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
@@ -61,10 +63,30 @@ export function createApp(prisma: PrismaClient) {
     legacyHeaders: false,
   });
 
-  app.use(
-    (pinoHttp as unknown as (opts?: Options) => express.RequestHandler)({
-      genReqId: () => randomUUID(),
-      autoLogging: true,
+  const logDir = 'logs';
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir);
+  }
+
+  const fileStream = createStream('app.log', {
+    size: '10M',
+    interval: '1d',
+    maxFiles: 7,
+    path: logDir,
+  });
+
+  const streams = [{ stream: fileStream }];
+  if (process.env.NODE_ENV !== 'production') {
+    streams.push({
+      stream: pino.transport({
+        target: 'pino-pretty',
+        options: { translateTime: 'SYS:standard' },
+      }),
+    });
+  }
+
+  const logger = pino(
+    {
       redact: {
         paths: [
           'req.headers.authorization',
@@ -77,10 +99,15 @@ export function createApp(prisma: PrismaClient) {
         ],
         censor: '[REDACTED]',
       },
-      transport:
-        process.env.NODE_ENV === 'production'
-          ? undefined
-          : { target: 'pino-pretty', options: { translateTime: 'SYS:standard' } },
+    },
+    pino.multistream(streams),
+  );
+
+  app.use(
+    (pinoHttp as unknown as (opts?: Options) => express.RequestHandler)({
+      genReqId: () => randomUUID(),
+      autoLogging: true,
+      logger,
     }),
   );
 


### PR DESCRIPTION
## Summary
- rotate backend logs daily with size limit and retain 7 files
- document log rotation behavior and storage path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ace37bf5b4832598f45d29048e2300