### PR TITLE
feat: add admin orders view

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,8 @@ import { createProductsRouter } from './routes/products.js';
 import { createCheckoutRouter } from './routes/checkout.js';
 // eslint-disable-next-line import/no-unresolved
 import { createWebhookRouter } from './routes/webhook.js';
+// eslint-disable-next-line import/no-unresolved
+import { createAdminRouter } from './routes/admin.js';
 
 interface RequestWithLog extends express.Request {
   log?: Logger;
@@ -141,6 +143,7 @@ export function createApp(prisma: PrismaClient) {
   app.use('/checkout', createCheckoutRouter(prisma));
   app.use('/webhook/mercadopago', webhookLimiter);
   app.use('/webhook', createWebhookRouter(prisma));
+  app.use('/admin', createAdminRouter(prisma));
 
   app.get('/api/users', async (req, res, next) => {
     try {

--- a/backend/src/middleware/role.ts
+++ b/backend/src/middleware/role.ts
@@ -1,0 +1,12 @@
+import type { RequestHandler } from 'express';
+import type { User } from '@prisma/client';
+
+export function requireRole(role: string): RequestHandler {
+  return (req, res, next) => {
+    const user = req.user as User | undefined;
+    if (!user || user.role !== role) {
+      return res.status(403).json({ ok: false, error: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,42 @@
+import express from 'express';
+import passport from 'passport';
+import type { PrismaClient } from '@prisma/client';
+// eslint-disable-next-line import/no-unresolved
+import { requireRole } from '../middleware/role.js';
+
+export function createAdminRouter(prisma: PrismaClient) {
+  const router = express.Router();
+
+  router.get(
+    '/orders',
+    passport.authenticate('jwt', { session: false }),
+    requireRole('ADMIN'),
+    async (req, res, next) => {
+      const page = parseInt((req.query.page as string) || '1', 10);
+      const limit = parseInt((req.query.limit as string) || '10', 10);
+      const skip = (page - 1) * limit;
+      try {
+        const [orders, total] = await Promise.all([
+          prisma.order.findMany({
+            select: { id: true, status: true, total_cents: true, createdAt: true },
+            orderBy: { createdAt: 'desc' },
+            skip,
+            take: limit,
+          }),
+          prisma.order.count(),
+        ]);
+        const mapped = orders.map((o) => ({
+          id: o.id,
+          status: o.status,
+          total_cents: o.total_cents,
+          created_at: o.createdAt.toISOString(),
+        }));
+        res.json({ orders: mapped, total, page, limit });
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  return router;
+}

--- a/frontend/src/pages/AdminOrdersPage.vue
+++ b/frontend/src/pages/AdminOrdersPage.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="q-pa-md">
+    <q-table
+      title="Orders"
+      :rows="orders"
+      :columns="columns"
+      row-key="id"
+      :loading="loading"
+      :pagination="pagination"
+      @request="onRequest"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAuthStore } from 'src/stores/auth';
+import type { QTableProps } from 'quasar';
+
+interface Order {
+  id: number;
+  status: string;
+  total_cents: number;
+  created_at: string;
+}
+
+const apiBase = import.meta.env.VITE_API_BASE_URL;
+const auth = useAuthStore();
+const orders = ref<Order[]>([]);
+const loading = ref(false);
+const pagination = ref({ page: 1, rowsPerPage: 10, rowsNumber: 0 });
+
+const columns: QTableProps['columns'] = [
+  { name: 'id', label: 'ID', field: 'id', align: 'left' },
+  { name: 'status', label: 'Estado', field: 'status', align: 'left' },
+  {
+    name: 'total',
+    label: 'Total',
+    field: (row: Order) =>
+      (row.total_cents / 100).toLocaleString('es-MX', {
+        style: 'currency',
+        currency: 'MXN',
+      }),
+  },
+  {
+    name: 'created_at',
+    label: 'Fecha',
+    field: (row: Order) => new Date(row.created_at).toLocaleString(),
+  },
+];
+
+async function fetchOrders(page = 1, limit = 10) {
+  loading.value = true;
+  try {
+    const res = await fetch(`${apiBase}/admin/orders?page=${page}&limit=${limit}`, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      orders.value = data.orders;
+      pagination.value.page = data.page;
+      pagination.value.rowsPerPage = data.limit;
+      pagination.value.rowsNumber = data.total;
+    }
+  } finally {
+    loading.value = false;
+  }
+}
+
+function onRequest(props: { pagination: { page: number; rowsPerPage: number } }) {
+  const { page, rowsPerPage } = props.pagination;
+  fetchOrders(page, rowsPerPage);
+}
+
+fetchOrders();
+</script>

--- a/frontend/src/router/guard.ts
+++ b/frontend/src/router/guard.ts
@@ -3,10 +3,16 @@ import type { Pinia } from 'pinia';
 import { useAuthStore } from '../stores/auth';
 
 export function setupAuthGuard(router: Router, pinia: Pinia) {
-  router.beforeEach((to) => {
+  router.beforeEach(async (to) => {
     const auth = useAuthStore(pinia);
+    if (auth.token && !auth.user) {
+      await auth.fetchMe();
+    }
     if (to.meta.requiresAuth && !auth.isAuthenticated) {
       return '/login';
+    }
+    if (to.meta.requiresAdmin && !auth.isAdmin) {
+      return '/';
     }
   });
 }

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -13,6 +13,11 @@ const routes: RouteRecordRaw[] = [
       { path: 'checkout/failure', component: () => import('pages/CheckoutFailurePage.vue') },
       { path: 'checkout/pending', component: () => import('pages/CheckoutPendingPage.vue') },
       { path: 'orders', component: () => import('pages/OrdersPage.vue'), meta: { requiresAuth: true } },
+      {
+        path: 'admin',
+        component: () => import('pages/AdminOrdersPage.vue'),
+        meta: { requiresAuth: true, requiresAdmin: true },
+      },
     ],
   },
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,34 +1,63 @@
 import { defineStore } from 'pinia';
 
+interface User {
+  id: string;
+  email: string;
+  name?: string | null;
+  role: string;
+  createdAt: string;
+}
+
 interface AuthState {
   token: string | null;
+  user: User | null;
 }
+
+const apiBase = import.meta.env.VITE_API_BASE_URL || '';
 
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
     token: localStorage.getItem('token'),
+    user: null,
   }),
   getters: {
     isAuthenticated: (state) => !!state.token,
+    isAdmin: (state) => state.user?.role === 'ADMIN',
   },
   actions: {
-    login(email: string, password: string) {
-      void email;
-      void password;
-      // TODO: replace with real API call
-      this.token = 'fake-token';
+    async login(email: string, password: string) {
+      const res = await fetch(`${apiBase}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) throw new Error('Login failed');
+      const data = await res.json();
+      this.token = data.token;
       localStorage.setItem('token', this.token);
+      await this.fetchMe();
     },
-    register(email: string, name: string, password: string) {
-      void email;
-      void name;
-      void password;
-      // TODO: replace with real API call
-      this.token = 'fake-token';
-      localStorage.setItem('token', this.token);
+    async register(email: string, name: string, password: string) {
+      const res = await fetch(`${apiBase}/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password, name }),
+      });
+      if (!res.ok) throw new Error('Register failed');
+      await this.login(email, password);
+    },
+    async fetchMe() {
+      if (!this.token) return;
+      const res = await fetch(`${apiBase}/auth/me`, {
+        headers: { Authorization: `Bearer ${this.token}` },
+      });
+      if (res.ok) {
+        this.user = await res.json();
+      }
     },
     logout() {
       this.token = null;
+      this.user = null;
       localStorage.removeItem('token');
     },
   },

--- a/frontend/test/authStore.spec.ts
+++ b/frontend/test/authStore.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useAuthStore } from '../src/stores/auth';
 
@@ -6,12 +6,30 @@ describe('useAuthStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     localStorage.clear();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url.endsWith('/auth/login')) {
+          return {
+            ok: true,
+            json: async () => ({ token: 'fake-token' }),
+          } as Response;
+        }
+        if (url.endsWith('/auth/me')) {
+          return {
+            ok: true,
+            json: async () => ({ id: '1', email: 'a@a.com', role: 'ADMIN', createdAt: new Date().toISOString() }),
+          } as Response;
+        }
+        return { ok: false } as Response;
+      }),
+    );
   });
 
-  it('sets and clears token', () => {
+  it('sets and clears token', async () => {
     const auth = useAuthStore();
     expect(auth.isAuthenticated).toBe(false);
-    auth.login('a@a.com', 'secret');
+    await auth.login('a@a.com', 'secret');
     expect(auth.isAuthenticated).toBe(true);
     expect(localStorage.getItem('token')).toBeTruthy();
     auth.logout();


### PR DESCRIPTION
## Summary
- secure admin endpoints with role middleware
- list orders with pagination via new GET /admin/orders endpoint
- add minimal admin UI with protected route and paginated table

## Testing
- `npm test` *(backend: failed - Error: Failed to load url rotating-file-stream)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ace5554d908325b08504e516f878f6