### PR TITLE
Add product cart E2E test and demo deployment config

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -1,0 +1,9 @@
+# Demo environment configuration
+# Backend variables
+DATABASE_URL=postgresql://user:password@dbhost:5432/spa_ecommerce
+JWT_SECRET=supersecret
+MP_ACCESS_TOKEN=your_sandbox_access_token
+MP_ALLOWED_IPS=*
+
+# Frontend variables
+VITE_API_BASE_URL=https://demo.api.example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,35 @@ jobs:
           node-version: '20'
       - run: npm ci
       - run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: [backend, frontend, be_test, fe_test]
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: spa_ecommerce
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/spa_ecommerce
+      JWT_SECRET: testsecret
+      MP_ACCESS_TOKEN: test
+      MP_ALLOWED_IPS: "*"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run db:generate -w backend
+      - run: npx prisma migrate deploy --schema backend/prisma/schema.prisma
+      - run: npm run e2e

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ yarn-error.log*
 .env
 .env.*
 !.env.example
+!.env.demo

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -19,6 +19,14 @@ export default defineConfig({
         async getOrder(id: number) {
           return prisma.order.findUnique({ where: { id } });
         },
+        async createProduct(data: {
+          name: string;
+          slug: string;
+          price_cents: number;
+          stock?: number;
+        }) {
+          return prisma.product.create({ data });
+        },
       });
     },
   },

--- a/cypress/e2e/full-flow.cy.ts
+++ b/cypress/e2e/full-flow.cy.ts
@@ -1,34 +1,53 @@
 /// <reference types="cypress" />
 
 describe('checkout flow', () => {
-  it('registers, logs in, creates order and processes webhook', () => {
+  it('registers, adds product to cart, creates order and processes webhook', () => {
     const api = Cypress.env('apiUrl');
     const email = `user${Date.now()}@test.com`;
     const password = 'Password123';
 
-    cy.request('POST', `${api}/auth/register`, { email, password }).its('status').should('eq', 201);
+    cy.task('createProduct', {
+      name: 'Test Product',
+      slug: `test-product-${Date.now()}`,
+      price_cents: 500,
+      stock: 10,
+    }).then((product) => {
+      const productId = product.id;
 
-    cy.request('POST', `${api}/auth/login`, { email, password })
-      .its('body.token')
-      .then((token) => {
-        cy.request({
-          method: 'POST',
-          url: `${api}/checkout/create-order`,
-          body: { items: [{ productId: 1, qty: 1 }] },
-          headers: { Authorization: `Bearer ${token}` },
-        }).then((orderRes) => {
-          const orderId = orderRes.body.orderId;
+      cy.request('POST', `${api}/auth/register`, { email, password })
+        .its('status')
+        .should('eq', 201);
 
-          // simulate MercadoPago webhook using mock mode
-          cy.request('POST', `${api}/webhook/mercadopago`, {
-            mp_payment_id: 'test-payment',
-            orderId,
-            payment_status: 'approved',
-          }).its('status').should('eq', 200);
+      cy.request('POST', `${api}/auth/login`, { email, password })
+        .its('body.token')
+        .then((token) => {
+          const cart = [] as { productId: number; qty: number }[];
 
-          // verify order status updated to APPROVED
-          cy.task('getOrder', orderId).its('status').should('eq', 'APPROVED');
+          // simulate user adding product to cart
+          cart.push({ productId, qty: 1 });
+          expect(cart).to.have.length(1);
+
+          cy.request({
+            method: 'POST',
+            url: `${api}/checkout/create-order`,
+            body: { items: cart },
+            headers: { Authorization: `Bearer ${token}` },
+          }).then((orderRes) => {
+            const orderId = orderRes.body.orderId;
+
+            // simulate MercadoPago webhook using mock mode
+            cy.request('POST', `${api}/webhook/mercadopago`, {
+              mp_payment_id: 'test-payment',
+              orderId,
+              payment_status: 'approved',
+            })
+              .its('status')
+              .should('eq', 200);
+
+            // verify order status updated to APPROVED
+            cy.task('getOrder', orderId).its('status').should('eq', 'APPROVED');
+          });
         });
-      });
+    });
   });
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "workspaces": ["backend", "frontend"],
   "scripts": {
-    "e2e": "MP_USE_MOCK=1 start-server-and-test \"npm run dev -w backend\" http://localhost:3000 \"cypress run\""
+    "e2e": "MP_USE_MOCK=1 start-server-and-test \"npm run dev -w backend\" http://localhost:3000/health \"cypress run\""
   },
   "devDependencies": {
     "cypress": "^13.7.0",

--- a/scripts/demo-deploy-backend.sh
+++ b/scripts/demo-deploy-backend.sh
@@ -4,6 +4,12 @@
 
 set -euo pipefail
 
+if [ -f .env.demo ]; then
+  set -a
+  source .env.demo
+  set +a
+fi
+
 render services deploy spa-ecommerce-backend \
   --branch main \
   --env DATABASE_URL="$DATABASE_URL" \

--- a/scripts/demo-deploy-frontend.sh
+++ b/scripts/demo-deploy-frontend.sh
@@ -3,4 +3,10 @@
 
 set -euo pipefail
 
+if [ -f .env.demo ]; then
+  set -a
+  source .env.demo
+  set +a
+fi
+
 vercel deploy frontend --prod --env VITE_API_BASE_URL="$VITE_API_BASE_URL"


### PR DESCRIPTION
## Summary
- extend Cypress flow to seed a product and simulate adding it to cart before checkout
- run Cypress E2E tests in CI with Postgres service
- add demo deployment scripts and env example for HTTPS demo

## Testing
- `npm run db:generate -w backend`
- `npx prisma db push --schema backend/prisma/schema.prisma`
- `npm run e2e` *(fails: Cypress executable not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aced073d0c832588dd1a4f53fe4558