### PR TITLE
feat: validate cart in e2e and prepare demo deploy

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -1,9 +1,9 @@
 # Demo environment configuration
 # Backend variables
-DATABASE_URL=postgresql://user:password@dbhost:5432/spa_ecommerce
-JWT_SECRET=supersecret
-MP_ACCESS_TOKEN=your_sandbox_access_token
-MP_ALLOWED_IPS=*
+DATABASE_URL=postgresql://demo_user:demo_pass@demo-db:5432/spa_ecommerce
+JWT_SECRET=demo_supersecret
+MP_ACCESS_TOKEN=TEST-1234567890123456-012345-1234567890abcdef-012345-abcdef1234567890abcdef1234567890-012345678
+MP_ALLOWED_IPS=0.0.0.0/0
 
 # Frontend variables
-VITE_API_BASE_URL=https://demo.api.example.com
+VITE_API_URL=https://demo.api.example.com

--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ JWT_EXPIRES_IN=7d
 MP_ACCESS_TOKEN=your-token
 MP_ALLOWED_IPS=1.2.3.4,5.6.7.8
 # Frontend
-VITE_API_BASE_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -35,3 +35,38 @@ docker compose up --build
 
 ## Licencia
 [MIT](LICENSE)
+
+## Demo Deployment
+
+Ejemplo rápido de cómo publicar una demo en producción usando **Render** para el backend y **Vercel** para el frontend. Revisa `.env.demo` para valores de referencia.
+
+### Backend (Render)
+
+1. Crea un servicio desde la carpeta `backend`.
+2. Configura variables de entorno:
+
+   ```
+   DATABASE_URL=postgresql://demo_user:demo_pass@demo-db:5432/spa_ecommerce
+   JWT_SECRET=demo_supersecret
+   MP_ACCESS_TOKEN=TEST-1234567890123456-012345-1234567890abcdef-012345-abcdef1234567890abcdef1234567890-012345678
+   MP_ALLOWED_IPS=0.0.0.0/0
+   CORS_ORIGIN=https://demo.miapp.com
+   ```
+
+3. Usa `npm install && npm run build` como comando de build y `npm run start` como start command.
+
+### Frontend (Vercel)
+
+1. Despliega la carpeta `frontend` como proyecto estático.
+2. Define la variable de entorno:
+
+   ```
+   VITE_API_URL=https://<tu-backend-demonstrativo>
+   ```
+
+3. Vercel detectará el framework y construirá con `npm install && npm run build`.
+
+### Dominio y MercadoPago
+
+- Apunta un dominio (p.ej. `demo.miapp.com`) al frontend y habilita HTTPS.
+- Utiliza credenciales **sandbox** de MercadoPago para todas las pruebas.

--- a/cypress/e2e/full-flow.cy.ts
+++ b/cypress/e2e/full-flow.cy.ts
@@ -21,31 +21,44 @@ describe('checkout flow', () => {
       cy.request('POST', `${api}/auth/login`, { email, password })
         .its('body.token')
         .then((token) => {
-          const cart = [] as { productId: number; qty: number }[];
-
-          // simulate user adding product to cart
-          cart.push({ productId, qty: 1 });
-          expect(cart).to.have.length(1);
-
           cy.request({
             method: 'POST',
-            url: `${api}/checkout/create-order`,
-            body: { items: cart },
+            url: `${api}/cart`,
+            body: { productId, qty: 1 },
             headers: { Authorization: `Bearer ${token}` },
-          }).then((orderRes) => {
-            const orderId = orderRes.body.orderId;
+          })
+            .its('status')
+            .should('eq', 200);
 
-            // simulate MercadoPago webhook using mock mode
-            cy.request('POST', `${api}/webhook/mercadopago`, {
-              mp_payment_id: 'test-payment',
-              orderId,
-              payment_status: 'approved',
-            })
-              .its('status')
-              .should('eq', 200);
+          cy.request({
+            method: 'GET',
+            url: `${api}/cart`,
+            headers: { Authorization: `Bearer ${token}` },
+          }).then((cartRes) => {
+            const items = cartRes.body.items;
+            expect(items).to.have.length(1);
+            expect(items[0]).to.include({ productId, qty: 1 });
 
-            // verify order status updated to APPROVED
-            cy.task('getOrder', orderId).its('status').should('eq', 'APPROVED');
+            cy.request({
+              method: 'POST',
+              url: `${api}/checkout/create-order`,
+              body: { items },
+              headers: { Authorization: `Bearer ${token}` },
+            }).then((orderRes) => {
+              const orderId = orderRes.body.orderId;
+
+              // simulate MercadoPago webhook using mock mode
+              cy.request('POST', `${api}/webhook/mercadopago`, {
+                mp_payment_id: 'test-payment',
+                orderId,
+                payment_status: 'approved',
+              })
+                .its('status')
+                .should('eq', 200);
+
+              // verify order status updated to APPROVED
+              cy.task('getOrder', orderId).its('status').should('eq', 'APPROVED');
+            });
           });
         });
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,6 @@ services:
     build: ./frontend
     env_file: [.env]
     environment:
-      VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://localhost:3000}
+      VITE_API_URL: ${VITE_API_URL:-http://localhost:3000}
     ports: ["9000:80"]
 volumes: { db_data: {} }

--- a/docs/demo-deployment.md
+++ b/docs/demo-deployment.md
@@ -22,7 +22,7 @@ CORS_ORIGIN=https://demo.example.com
 2. Set the environment variable used by Vite:
 
 ```
-VITE_API_BASE_URL=https://your-backend.example.com
+VITE_API_URL=https://your-backend.example.com
 ```
 
 ## Domain

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:3000
+VITE_API_URL=http://localhost:3000

--- a/frontend/src/pages/AdminOrdersPage.vue
+++ b/frontend/src/pages/AdminOrdersPage.vue
@@ -24,7 +24,8 @@ interface Order {
   created_at: string;
 }
 
-const apiBase = import.meta.env.VITE_API_BASE_URL;
+const apiBase =
+  import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL;
 const auth = useAuthStore();
 const orders = ref<Order[]>([]);
 const loading = ref(false);

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -54,7 +54,8 @@ const subtotal = computed(() => cartStore.subtotal);
 const total = computed(() => cartStore.total);
 const currency = computed(() => cart.value[0]?.currency || 'USD');
 const $q = useQuasar();
-const apiBase = import.meta.env.VITE_API_BASE_URL;
+const apiBase =
+  import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL;
 
 async function pay() {
   try {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -13,7 +13,8 @@ interface AuthState {
   user: User | null;
 }
 
-const apiBase = import.meta.env.VITE_API_BASE_URL || '';
+const apiBase =
+  import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL || '';
 
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({

--- a/scripts/demo-deploy-frontend.sh
+++ b/scripts/demo-deploy-frontend.sh
@@ -9,4 +9,4 @@ if [ -f .env.demo ]; then
   set +a
 fi
 
-vercel deploy frontend --prod --env VITE_API_BASE_URL="$VITE_API_BASE_URL"
+vercel deploy frontend --prod --env VITE_API_URL="$VITE_API_URL"


### PR DESCRIPTION
## Summary
- test full checkout flow using real cart endpoint
- switch demo config to VITE_API_URL with MercadoPago sandbox token
- document Render + Vercel demo deployment steps

## Testing
- `npm run e2e` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68acf49271508325af34e02cd40f8214