### PR TITLE
ci: generate prisma before e2e and document demo deploy

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -4,6 +4,7 @@ DATABASE_URL=postgresql://demo_user:demo_pass@demo-db:5432/spa_ecommerce
 JWT_SECRET=demo_supersecret
 MP_ACCESS_TOKEN=TEST-1234567890123456-012345-1234567890abcdef-012345-abcdef1234567890abcdef1234567890-012345678
 MP_ALLOWED_IPS=0.0.0.0/0
+CORS_ORIGIN=https://demo.miapp.com
 
 # Frontend variables
-VITE_API_URL=https://demo.api.example.com
+VITE_API_URL=https://api.demo.miapp.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: spa_ecommerce
+          POSTGRES_DB: spa_ecommerce_test
         ports:
           - 5432:5432
         options: >-
@@ -105,7 +105,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/spa_ecommerce
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/spa_ecommerce_test
       JWT_SECRET: testsecret
       MP_ACCESS_TOKEN: test
       MP_ALLOWED_IPS: "*"
@@ -115,6 +115,6 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - run: npm run db:generate -w backend
+      - run: npx prisma generate --schema backend/prisma/schema.prisma
       - run: npx prisma migrate deploy --schema backend/prisma/schema.prisma
       - run: npm run e2e

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ docker compose up --build
 ## Licencia
 [MIT](LICENSE)
 
-## Demo Deployment
+## Deploy Demo
 
-Ejemplo rápido de cómo publicar una demo en producción usando **Render** para el backend y **Vercel** para el frontend. Revisa `.env.demo` para valores de referencia.
+Guía para publicar una demo con backend y frontend reales usando credenciales **sandbox**. Revisa `.env.demo` para valores de referencia.
 
 ### Backend (Render)
 
-1. Crea un servicio desde la carpeta `backend`.
-2. Configura variables de entorno:
+1. Render puede leer `render.yaml` y crear un servicio web HTTPS para la carpeta `backend`.
+2. Define las variables de entorno del archivo `.env.demo`:
 
    ```
    DATABASE_URL=postgresql://demo_user:demo_pass@demo-db:5432/spa_ecommerce
@@ -53,20 +53,17 @@ Ejemplo rápido de cómo publicar una demo en producción usando **Render** para
    CORS_ORIGIN=https://demo.miapp.com
    ```
 
-3. Usa `npm install && npm run build` como comando de build y `npm run start` como start command.
+3. Usa `npm install && npm run build` como build command y `npm run start` como start command.
+4. Render expone automáticamente el servicio con HTTPS.
 
 ### Frontend (Vercel)
 
-1. Despliega la carpeta `frontend` como proyecto estático.
-2. Define la variable de entorno:
-
-   ```
-   VITE_API_URL=https://<tu-backend-demonstrativo>
-   ```
-
-3. Vercel detectará el framework y construirá con `npm install && npm run build`.
+1. Despliega la carpeta `frontend` empleando la configuración de `frontend/vercel.json`.
+2. Configura la variable de entorno `VITE_API_URL` apuntando al backend (p.ej. `https://api.demo.miapp.com`).
+3. Vercel ejecutará `npm install && npm run build` y publicará `dist/spa` con HTTPS.
 
 ### Dominio y MercadoPago
 
-- Apunta un dominio (p.ej. `demo.miapp.com`) al frontend y habilita HTTPS.
-- Utiliza credenciales **sandbox** de MercadoPago para todas las pruebas.
+- Apunta un dominio público, como `demo.miapp.com`, al despliegue del frontend y habilita HTTPS.
+- El backend puede exponerse como `api.demo.miapp.com` o usar el dominio por defecto de Render.
+- Ejecuta el flujo de pago con credenciales **sandbox** de MercadoPago para verificar la integración.

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist/spa",
+  "framework": "vite",
+  "env": {
+    "VITE_API_URL": "https://api.demo.miapp.com"
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,19 @@
+services:
+  - type: web
+    name: spa-ecommerce-demo
+    env: node
+    plan: free
+    rootDir: backend
+    buildCommand: npm install && npm run build
+    startCommand: npm run start
+    envVars:
+      - key: DATABASE_URL
+        value: postgresql://demo_user:demo_pass@demo-db:5432/spa_ecommerce
+      - key: JWT_SECRET
+        value: demo_supersecret
+      - key: MP_ACCESS_TOKEN
+        value: TEST-1234567890123456-012345-1234567890abcdef-012345-abcdef1234567890abcdef1234567890-012345678
+      - key: MP_ALLOWED_IPS
+        value: 0.0.0.0/0
+      - key: CORS_ORIGIN
+        value: https://demo.miapp.com


### PR DESCRIPTION
## Summary
- run `npx prisma generate` before Cypress tests and use dedicated test database
- add Render and Vercel demo deployment configs and update environment example

## Testing
- `npx prisma generate --schema backend/prisma/schema.prisma`
- `npx prisma migrate deploy --schema backend/prisma/schema.prisma` *(fails: Can't reach database server at `localhost:5432`)*
- `JWT_SECRET=testsecret MP_ACCESS_TOKEN=test MP_ALLOWED_IPS='*' npm run e2e` *(fails: Command failed with exit code 1: cypress run)*

------
https://chatgpt.com/codex/tasks/task_e_68acf81d31c48325a4995219ac19ee21