### PR TITLE
Fix admin router factory integration

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,17 +1,30 @@
 import express from 'express';
 import passport from 'passport';
-import adminRouter from './routes/admin.js';
+import { PrismaClient } from '@prisma/client';
+import { createAdminRouter } from './routes/admin.js';
 import './middleware/auth.js';
 
 const app = express();
+const prisma = new PrismaClient();
+
 app.use(express.json());
 app.use(passport.initialize());
 
-app.use('/api/admin', adminRouter);
+app.use('/api/admin', createAdminRouter(prisma));
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`API listening on port ${PORT}`);
+});
+
+process.on('SIGINT', async () => {
+  await prisma.$disconnect();
+  process.exit(0);
+});
+
+process.on('SIGTERM', async () => {
+  await prisma.$disconnect();
+  process.exit(0);
 });
 
 export default app;


### PR DESCRIPTION
## Summary
- instantiate `createAdminRouter` with `PrismaClient` in backend `index.ts`
- add graceful Prisma shutdown handlers

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: Prisma Client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_68ad04cda99c8325bc5eee30372d7f7e