### PR TITLE
feat: add shipping cost and abandoned cart job

### DIFF
--- a/backend/prisma/migrations/20251204000000_add_shipping_cents_to_order/migration.sql
+++ b/backend/prisma/migrations/20251204000000_add_shipping_cents_to_order/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Order" ADD COLUMN "shipping_cents" INTEGER NOT NULL DEFAULT 0;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Order {
   userId     Int?
   status     OrderStatus @default(PENDING)
   totalCents Int
+  shipping_cents Int     @default(0)
   items      OrderItem[]
   createdAt  DateTime    @default(now())
   updatedAt  DateTime    @updatedAt

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -16,7 +16,7 @@ import { createAuthRouter } from './routes/auth.js';
 // eslint-disable-next-line import/no-unresolved
 import { createProductsRouter } from './routes/products.js';
 // eslint-disable-next-line import/no-unresolved
-import { createCheckoutRouter } from './routes/checkout.js';
+import { createOrdersRouter } from './routes/orders.js';
 // eslint-disable-next-line import/no-unresolved
 import { createWebhookRouter } from './routes/webhook.js';
 // eslint-disable-next-line import/no-unresolved
@@ -146,7 +146,7 @@ export function createApp(prisma: PrismaClient) {
 
   app.use('/auth', authLimiter, createAuthRouter(prisma));
   app.use('/products', createProductsRouter(prisma));
-  app.use('/checkout', createCheckoutRouter(prisma));
+  app.use('/checkout', createOrdersRouter(prisma));
   app.use('/webhook/mercadopago', webhookLimiter);
   app.use('/webhook', createWebhookRouter(prisma));
   app.use('/admin/reviews', createReviewsRouter(prisma));

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,8 @@ import passport from 'passport';
 import { PrismaClient } from '@prisma/client';
 import { createAdminRouter } from './routes/admin.js';
 import { createReviewsRouter } from './routes/reviews.js';
+// eslint-disable-next-line import/no-unresolved
+import { startAbandonedCartJob } from './jobs/abandonedCart.js';
 import './middleware/auth.js';
 
 const app = express();
@@ -13,6 +15,8 @@ app.use(passport.initialize());
 
 app.use('/api/admin/reviews', createReviewsRouter(prisma));
 app.use('/api/admin', createAdminRouter(prisma));
+
+startAbandonedCartJob(prisma);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/backend/src/jobs/abandonedCart.ts
+++ b/backend/src/jobs/abandonedCart.ts
@@ -1,16 +1,26 @@
 import cron from 'node-cron';
+import type { PrismaClient } from '@prisma/client';
 // eslint-disable-next-line import/no-unresolved
 import { sendMail } from '../utils/mailer.js';
 
-export function startAbandonedCartJob() {
+export function startAbandonedCartJob(prisma: PrismaClient) {
   // Runs every 6 hours
   cron.schedule('0 */6 * * *', async () => {
-    // This is a placeholder implementation. In a real app you would query the DB
-    // for carts that haven't been checked out and send a reminder email.
-    await sendMail({
-      to: 'demo@example.com',
-      subject: 'Recordatorio de carrito',
-      text: 'Tienes productos esperando en tu carrito.',
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const pending = await prisma.order.findMany({
+      where: { status: 'PENDING', updatedAt: { lt: cutoff } },
+      include: { user: true },
     });
+    await Promise.all(
+      pending
+        .filter((o) => o.user?.email)
+        .map((o) =>
+          sendMail({
+            to: o.user!.email!,
+            subject: 'Recordatorio de carrito',
+            text: `Tienes un pedido pendiente (#${o.id}) en nuestra tienda.`,
+          }),
+        ),
+    );
   });
 }

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -9,6 +9,7 @@ import { sendMail } from '../utils/mailer.js';
 const createOrderSchema = z.object({
   email: z.string().email().optional(),
   couponId: z.number().int().optional(),
+  zone: z.string().min(1),
   items: z
     .array(
       z.object({
@@ -19,7 +20,7 @@ const createOrderSchema = z.object({
     .min(1),
 });
 
-export function createCheckoutRouter(prisma: PrismaClient) {
+export function createOrdersRouter(prisma: PrismaClient) {
   const router = express.Router();
 
   router.post('/create-order', async (req, res, next) => {
@@ -28,7 +29,7 @@ export function createCheckoutRouter(prisma: PrismaClient) {
       return res.status(400).json({ error: parsed.error.flatten() });
     }
 
-    const { items, email, couponId } = parsed.data;
+    const { items, email, couponId, zone } = parsed.data;
     try {
       const ids = items.map((i) => i.productId);
       const products = await prisma.product.findMany({
@@ -51,6 +52,19 @@ export function createCheckoutRouter(prisma: PrismaClient) {
         return sum + item.qty * product.price_cents;
       }, 0);
 
+      const weight = items.reduce((sum, item) => sum + item.qty, 0);
+      const rate = await prisma.shippingRate.findFirst({
+        where: {
+          zone,
+          minWeight: { lte: weight },
+          maxWeight: { gte: weight },
+        },
+      });
+      if (!rate) {
+        return res.status(400).json({ error: 'Invalid shipping zone' });
+      }
+      const shippingCents = rate.priceCents;
+
       let discount = 0;
       if (couponId) {
         const coupon = await prisma.coupon.findUnique({ where: { id: couponId } });
@@ -64,7 +78,8 @@ export function createCheckoutRouter(prisma: PrismaClient) {
         data: {
           status: 'PENDING',
           currency: 'MXN',
-          total_cents: total - discount,
+          total_cents: total - discount + shippingCents,
+          shipping_cents: shippingCents,
           items: {
             create: items.map((item) => {
               const product = productMap.get(item.productId)!;

--- a/backend/test/checkout.integration.test.ts
+++ b/backend/test/checkout.integration.test.ts
@@ -34,10 +34,25 @@ class FakePrisma {
   orderToFind: any = null;
   updatedOrder: any = null;
 
+  shippingRates = [
+    { zone: 'NORTE', minWeight: 1, maxWeight: 10, priceCents: 500 },
+  ];
+
   product = {
     findMany: async ({ where }: any) => {
       const ids: number[] = where.id.in;
       return this.products.filter((p) => ids.includes(p.id));
+    },
+  };
+
+  shippingRate = {
+    findFirst: async ({ where }: any) => {
+      const weight = where.minWeight.lte;
+      return (
+        this.shippingRates.find(
+          (r) => r.zone === where.zone && r.minWeight <= weight && r.maxWeight >= weight,
+        ) || null
+      );
     },
   };
 
@@ -75,13 +90,17 @@ describe('checkout create-order', () => {
   it('creates an order with items and returns total', async () => {
     const res = await request(app)
       .post('/checkout/create-order')
-      .send({ items: [{ productId: 1, qty: 2 }, { productId: 5, qty: 1 }] })
+      .send({
+        items: [{ productId: 1, qty: 2 }, { productId: 5, qty: 1 }],
+        zone: 'NORTE',
+      })
       .expect(200);
 
-    expect(res.body.total_cents).toBe(79900);
+    expect(res.body.total_cents).toBe(80400);
     expect(prisma.createdOrder.status).toBe('PENDING');
     expect(prisma.createdOrder.currency).toBe('MXN');
-    expect(prisma.createdOrder.total_cents).toBe(79900);
+    expect(prisma.createdOrder.total_cents).toBe(80400);
+    expect(prisma.createdOrder.shipping_cents).toBe(500);
     expect(prisma.createdOrder.items.create).toEqual([
       { productId: 1, qty: 2, unit_price_cents: 10000 },
       { productId: 5, qty: 1, unit_price_cents: 59900 },
@@ -91,7 +110,7 @@ describe('checkout create-order', () => {
   it('fails when qty exceeds stock', async () => {
     await request(app)
       .post('/checkout/create-order')
-      .send({ items: [{ productId: 1, qty: 5 }] })
+      .send({ items: [{ productId: 1, qty: 5 }], zone: 'NORTE' })
       .expect(400);
     expect(prisma.createdOrder).toBeNull();
   });

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -91,12 +91,17 @@ async function zoneChanged(val: string) {
 
 async function pay() {
   try {
+    if (!selectedZone.value) {
+      $q.notify({ type: 'negative', message: 'Selecciona una zona de envío' });
+      return;
+    }
     const orderRes = await fetch(`${apiBase}/checkout/create-order`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         items: cart.value.map((l) => ({ productId: l.productId, qty: l.qty })),
         couponId: couponStore.coupon?.id,
+        zone: selectedZone.value,
       }),
     });
     if (!orderRes.ok) throw new Error('Error creando orden');


### PR DESCRIPTION
## Summary
- support shipping cost in orders
- remind users about abandoned carts via cron job
- ensure checkout sends shipping zone and validates selection

## Testing
- `npm test --workspace backend` *(fails: @prisma/client did not initialize yet)*
- `npm run lint --workspace backend` *(fails: Unable to resolve path to module './routes/admin.js')*


------
https://chatgpt.com/codex/tasks/task_e_68ad115c0b3483258d0112efc2a246f2