### PR TITLE
feat: prerender dynamic product routes

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,16 +1,22 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { quasar, transformAssetUrls } from '@quasar/vite-plugin';
 import prerender from 'vite-plugin-prerender';
+import { fetchProductRoutes } from '../scripts/fetchProductRoutes.js';
 
-export default defineConfig({
-  plugins: [
-    vue({
-      template: { transformAssetUrls }
-    }),
-    quasar(),
-    prerender({
-      routes: ['/', '/product/1'],
-    }),
-  ],
+export default defineConfig(async ({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const productRoutes = await fetchProductRoutes(env.VITE_API_URL);
+
+  return {
+    plugins: [
+      vue({
+        template: { transformAssetUrls },
+      }),
+      quasar(),
+      prerender({
+        routes: ['/', ...productRoutes],
+      }),
+    ],
+  };
 });

--- a/scripts/fetchProductRoutes.js
+++ b/scripts/fetchProductRoutes.js
@@ -1,0 +1,20 @@
+export async function fetchProductRoutes(apiUrl) {
+  if (!apiUrl) {
+    return [];
+  }
+  try {
+    const res = await fetch(`${apiUrl}/api/products`);
+    if (!res.ok) {
+      console.error(`Failed to fetch products: ${res.status}`);
+      return [];
+    }
+    const products = await res.json();
+    if (!Array.isArray(products)) {
+      return [];
+    }
+    return products.map((p) => `/product/${p.id}`);
+  } catch (err) {
+    console.error('Error fetching product routes:', err);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- prerender product pages by fetching product ids during build
- add helper script to fetch product routes from backend

## Testing
- `npm test -w frontend`
- `npm run build -w frontend` *(fails: Promises must be awaited, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68ad17e2be14832583cdd20e02a97ad9