### PR TITLE
Add payment webhook idempotency, security middlewares, logout, and web-vitals reporting

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -161,3 +161,11 @@ model Payment {
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
 }
+
+model PaymentEvent {
+  id        Int      @id @default(autoincrement())
+  orderId   Int
+  eventId   String   @unique
+  payload   Json
+  createdAt DateTime @default(now())
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,9 @@ import passport from 'passport';
 import http from 'http';
 import { Server } from 'socket.io';
 import jwt from 'jsonwebtoken';
+import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import { PrismaClient } from '@prisma/client';
 import {
   collectDefaultMetrics,
@@ -15,6 +18,9 @@ import { createReviewsRouter } from './routes/reviews.js';
 import { createCartRouter } from './routes/cart.js';
 import { createMetricsRouter } from './routes/metrics.js';
 import { createOrdersRouter } from './routes/orders.js';
+import { createAuthRouter } from './routes/auth.js';
+import { createProductsRouter } from './routes/products.js';
+import { createWebhookRouter } from './routes/webhook.js';
 // eslint-disable-next-line import/no-unresolved
 import { startAbandonedCartJob } from './jobs/abandonedCart.js';
 import './middleware/auth.js';
@@ -22,8 +28,43 @@ import './middleware/auth.js';
 const app = express();
 const prisma = new PrismaClient();
 
+const allowedOrigins = (process.env.CORS_ORIGIN || 'https://mi-front.com')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean);
+
+app.use(helmet());
+app.use(helmet.hsts({ maxAge: 31_536_000, includeSubDomains: true, preload: true }));
+app.use(helmet.noSniff());
+app.use(helmet.xssFilter());
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Not allowed by CORS'));
+    },
+    credentials: true,
+  }),
+);
+
 app.use(express.json());
 app.use(passport.initialize());
+
+const authLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const webhookLimiter = rateLimit({
+  windowMs: 60_000,
+  limit: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 // Metrics setup
 const register = new Registry();
@@ -58,8 +99,12 @@ app.use((req, res, next) => {
 });
 
 app.use('/api/metrics', createMetricsRouter(register));
+app.use('/api/auth', authLimiter, createAuthRouter(prisma));
+app.use('/api/products', createProductsRouter(prisma));
 app.use('/api/cart', createCartRouter(prisma));
 app.use('/checkout', createOrdersRouter(prisma, ordersCreatedCounter));
+app.use('/webhook/mercadopago', webhookLimiter);
+app.use('/webhook', createWebhookRouter(prisma));
 app.use('/api/admin/reviews', createReviewsRouter(prisma));
 app.use('/api/admin', createAdminRouter(prisma));
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -2,16 +2,23 @@ import passport from 'passport';
 import { Strategy as JwtStrategy, ExtractJwt } from 'passport-jwt';
 import { PrismaClient } from '@prisma/client';
 
+export const revokedTokens = new Set<string>();
+
 const prisma = new PrismaClient();
 
 const opts = {
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
   secretOrKey: process.env.JWT_SECRET || 'secret',
+  passReqToCallback: true,
 };
 
 passport.use(
-  new JwtStrategy(opts, async (payload, done) => {
+  new JwtStrategy(opts, async (req, payload, done) => {
     try {
+      const token = ExtractJwt.fromAuthHeaderAsBearerToken()(req) as string | null;
+      if (token && revokedTokens.has(token)) {
+        return done(null, false);
+      }
       const user = await prisma.user.findUnique({ where: { id: payload.sub } });
       if (!user) return done(null, false);
       return done(null, user);

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 // eslint-disable-next-line import/no-unresolved
 import { hashPassword, verifyPassword } from '../utils/password.js';
 import type { PrismaClient, User } from '@prisma/client';
+// eslint-disable-next-line import/no-unresolved
+import { revokedTokens } from '../middleware/auth.js';
 
 export const registerSchema = z.object({
   email: z.string().email(),
@@ -60,6 +62,14 @@ export function createAuthRouter(prisma: PrismaClient) {
     } catch (err) {
       next(err);
     }
+  });
+
+  router.post('/logout', passport.authenticate('jwt', { session: false }), (req, res) => {
+    const token = req.get('authorization')?.replace('Bearer ', '');
+    if (token) {
+      revokedTokens.add(token);
+    }
+    res.json({ ok: true });
   });
 
   router.get('/me', passport.authenticate('jwt', { session: false }), (req, res) => {

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -9,6 +9,14 @@ export function createMetricsRouter(register: Registry) {
     res.end(await register.metrics());
   });
 
+  router.post('/', (req, res) => {
+    // In a real scenario, we'd persist or aggregate these metrics
+    // For now, just log them for visibility
+    // eslint-disable-next-line no-console
+    console.log('Web Vitals metric', req.body);
+    res.status(204).end();
+  });
+
   return router;
 }
 

--- a/backend/src/routes/products.ts
+++ b/backend/src/routes/products.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import type { Prisma, PrismaClient, ProductStatus } from '@prisma/client';
+import { Prisma, type PrismaClient, ProductStatus } from '@prisma/client';
 
 export function createProductsRouter(prisma: PrismaClient) {
   const router = express.Router();

--- a/backend/src/routes/webhook.ts
+++ b/backend/src/routes/webhook.ts
@@ -26,18 +26,19 @@ export function createWebhookRouter(prisma: PrismaClient) {
   };
 
   router.post('/mercadopago', allowlist, async (req: RequestWithLog, res) => {
-    const mpPaymentId = req.body?.data?.id ?? req.body?.mp_payment_id ?? req.body?.id;
-    if (!mpPaymentId) {
-      req.log?.warn?.('mp_payment_id missing');
-      return res.status(400).json({ error: 'mp_payment_id missing' });
+    const eventId = req.body?.id ?? req.body?.eventId;
+    const mpPaymentId = req.body?.data?.id ?? req.body?.mp_payment_id;
+    if (!eventId || !mpPaymentId) {
+      req.log?.warn?.('event or payment id missing');
+      return res.status(400).json({ error: 'event id or payment id missing' });
     }
 
     try {
       const exists = await prisma.paymentEvent.findUnique({
-        where: { mp_payment_id: String(mpPaymentId) },
+        where: { eventId: String(eventId) },
       });
       if (exists) {
-        req.log?.info?.({ mp_payment_id: mpPaymentId }, 'Evento duplicado ignorado');
+        req.log?.info?.({ eventId }, 'Evento duplicado ignorado');
         return res.status(200).json({ status: 'ignored' });
       }
 
@@ -118,9 +119,8 @@ export function createWebhookRouter(prisma: PrismaClient) {
         await tx.paymentEvent.create({
           data: {
             orderId,
-            mp_payment_id: String(mpPaymentId),
-            status: orderStatus,
-            raw_payload: req.body as unknown as Prisma.JsonValue,
+            eventId: String(eventId),
+            payload: req.body as unknown as Prisma.JsonValue,
           },
         });
       });
@@ -141,7 +141,7 @@ export function createWebhookRouter(prisma: PrismaClient) {
       res.json({ ok: true });
     } catch (err) {
       if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
-        req.log?.info?.({ mp_payment_id: mpPaymentId }, 'Evento duplicado ignorado');
+        req.log?.info?.({ eventId }, 'Evento duplicado ignorado');
         return res.status(200).json({ status: 'ignored' });
       }
       if (err instanceof Error && err.message.startsWith('Insufficient stock')) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,13 +16,14 @@
   },
   "dependencies": {
     "@quasar/extras": "^1.16.4",
+    "axios": "^1.7.7",
     "pinia": "^3.0.3",
     "quasar": "^2.16.0",
     "socket.io-client": "^4.7.5",
     "vue": "^3.4.18",
+    "vue-i18n": "^9.13.1",
     "vue-router": "^4.0.12",
-    "axios": "^1.7.7",
-    "vue-i18n": "^9.13.1"
+    "web-vitals": "^3.5.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
@@ -38,9 +39,9 @@
     "prettier": "^3.3.3",
     "typescript": "~5.5.3",
     "vite-plugin-checker": "^0.9.0",
+    "vite-plugin-prerender": "^1.0.7",
     "vitest": "^3.2.4",
-    "vue-tsc": "^2.0.29",
-    "vite-plugin-prerender": "^1.0.7"
+    "vue-tsc": "^2.0.29"
   },
   "engines": {
     "node": ">=20",

--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -11,7 +11,7 @@ export default defineConfig((/* ctx */) => {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli-vite/boot-files
-    boot: ['socket', 'i18n'],
+    boot: ['socket', 'i18n', 'webVitals'],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#css
     css: ['app.scss'],

--- a/frontend/src/boot/webVitals.ts
+++ b/frontend/src/boot/webVitals.ts
@@ -1,0 +1,18 @@
+import { onCLS, onFID, onLCP, type Metric } from 'web-vitals';
+
+function sendToAnalytics(metric: Metric) {
+  try {
+    navigator.sendBeacon(
+      '/api/metrics',
+      JSON.stringify({ name: metric.name, value: metric.value, id: metric.id })
+    );
+  } catch {
+    // ignore errors
+  }
+}
+
+export default () => {
+  onCLS(sendToAnalytics);
+  onFID(sendToAnalytics);
+  onLCP(sendToAnalytics);
+};

--- a/frontend/src/components/ProductSearch.vue
+++ b/frontend/src/components/ProductSearch.vue
@@ -2,7 +2,7 @@
   <div class="row q-col-gutter-md items-start">
     <div class="col">
       <q-input
-        v-model="text"
+        v-model="search"
         debounce="300"
         placeholder="Buscar productos"
         dense
@@ -44,10 +44,10 @@ defineProps<Props>();
 
 const store = useProductsStore();
 
-const text = ref(store.filters.text);
+const search = ref(store.filters.search);
 const category = ref(store.filters.category);
 
-watch([text, category], () => {
-  store.setFilters({ text: text.value, category: category.value });
+watch([search, category], () => {
+  store.setFilters({ search: search.value, category: category.value });
 });
 </script>

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -34,7 +34,7 @@ function onAdd(product: any) {
 }
 
 onMounted(() => {
-  void productStore.fetchProducts(1, 12);
+  void productStore.fetchProducts(1, 12, { force: true });
 });
 </script>
 

--- a/frontend/src/stores/productsStore.ts
+++ b/frontend/src/stores/productsStore.ts
@@ -11,7 +11,7 @@ export interface Product {
 }
 
 interface Filters {
-  text: string;
+  search: string;
   category: string;
 }
 
@@ -30,7 +30,7 @@ export const useProductsStore = defineStore('products', {
     loading: false,
     error: null,
     filters: {
-      text: '',
+      search: '',
       category: '',
     },
   }),
@@ -40,7 +40,7 @@ export const useProductsStore = defineStore('products', {
   },
   actions: {
     search(query: string) {
-      this.setFilters({ text: query });
+      this.setFilters({ search: query });
     },
     setFilters(newFilters: Partial<Filters>) {
       this.filters = { ...this.filters, ...newFilters };
@@ -66,9 +66,9 @@ export const useProductsStore = defineStore('products', {
           page: page.toString(),
           limit: limit.toString(),
         });
-        if (this.filters.text) params.append('text', this.filters.text);
+        if (this.filters.search) params.append('search', this.filters.search);
         if (this.filters.category) params.append('category', this.filters.category);
-        const res = await fetch(`/products?${params.toString()}`);
+        const res = await fetch(`/api/products?${params.toString()}`);
         if (!res.ok) throw new Error('Failed to fetch products');
         const json = await res.json();
         this.pages[page] = json.data as Product[];

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(async ({ mode }) => {
       quasar(),
       prerender({
         routes: ['/', ...productRoutes],
+        staticDir: 'dist',
       }),
     ],
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,8 @@
         "socket.io-client": "^4.7.5",
         "vue": "^3.4.18",
         "vue-i18n": "^9.13.1",
-        "vue-router": "^4.0.12"
+        "vue-router": "^4.0.12",
+        "web-vitals": "^3.5.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.14.0",
@@ -19081,6 +19082,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
+      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",


### PR DESCRIPTION
## Summary
- add PaymentEvent model for webhook event dedupe
- apply helmet/cors/rate limiting in main server and expose product & auth routes
- implement logout with token revocation and frontend web-vitals reporting
- fix product search parameter usage across frontend

## Testing
- `npm test -w backend` *(fails: product and webhook tests)*
- `npm test -w frontend`
- `npm run lint -w backend` *(fails: existing lint errors)*
- `npm run lint -w frontend` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2394a4b48325914138fd550da2ae