### PR TITLE
feat: category filtering and order item consistency

### DIFF
--- a/backend/prisma/migrations/20251201000000_orders/migration.sql
+++ b/backend/prisma/migrations/20251201000000_orders/migration.sql
@@ -14,8 +14,8 @@ CREATE TABLE "public"."OrderItem" (
     "id" SERIAL NOT NULL,
     "orderId" INTEGER NOT NULL,
     "productId" INTEGER NOT NULL,
-    "qty" INTEGER NOT NULL,
-    "unit_price_cents" INTEGER NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "unitPriceCents" INTEGER NOT NULL,
     CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id"),
     CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "public"."Order"("id") ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT "OrderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "public"."Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -92,6 +92,7 @@ model OrderItem {
   product   Product @relation(fields: [productId], references: [id])
   productId Int
   quantity  Int
+  unitPriceCents Int
 }
 
 model Review {

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -15,7 +15,7 @@ const createOrderSchema = z.object({
     .array(
       z.object({
         productId: z.number().int().positive(),
-        qty: z.number().int().positive(),
+        quantity: z.number().int().positive(),
       }),
     )
     .min(1),
@@ -46,17 +46,17 @@ export function createOrdersRouter(
       const productMap = new Map(products.map((p) => [p.id, p]));
       for (const item of items) {
         const product = productMap.get(item.productId);
-        if (!product || item.qty > product.stock) {
+        if (!product || item.quantity > product.stock) {
           return res.status(400).json({ error: 'Insufficient stock' });
         }
       }
 
       const total = items.reduce((sum, item) => {
         const product = productMap.get(item.productId)!;
-        return sum + item.qty * product.price_cents;
+        return sum + item.quantity * product.price_cents;
       }, 0);
 
-      const weight = items.reduce((sum, item) => sum + item.qty, 0);
+      const weight = items.reduce((sum, item) => sum + item.quantity, 0);
       const rate = await prisma.shippingRate.findFirst({
         where: {
           zone,
@@ -89,8 +89,8 @@ export function createOrdersRouter(
               const product = productMap.get(item.productId)!;
               return {
                 productId: item.productId,
-                qty: item.qty,
-                unit_price_cents: product.price_cents,
+                quantity: item.quantity,
+                unitPriceCents: product.price_cents,
               };
             }),
           },
@@ -142,8 +142,8 @@ export function createOrdersRouter(
       const preference = await new Preference(mp).create({
         items: order.items.map((item) => ({
           title: item.product.name,
-          quantity: item.qty,
-          unit_price: item.unit_price_cents / 100,
+          quantity: item.quantity,
+          unit_price: item.unitPriceCents / 100,
           currency_id: 'MXN',
         })),
         back_urls: {

--- a/backend/src/routes/products.ts
+++ b/backend/src/routes/products.ts
@@ -8,6 +8,7 @@ export function createProductsRouter(prisma: PrismaClient) {
     const page = Number.parseInt(req.query.page as string, 10) || 1;
     const limit = Number.parseInt(req.query.limit as string, 10) || 10;
     const search = (req.query.search as string) || '';
+    const categoryParam = req.query.category;
 
     try {
       const where: Prisma.ProductWhereInput = {
@@ -19,6 +20,12 @@ export function createProductsRouter(prisma: PrismaClient) {
           { name: { contains: search, mode: 'insensitive' } },
           { description: { contains: search, mode: 'insensitive' } },
         ];
+      }
+      if (categoryParam) {
+        if (Array.isArray(categoryParam)) {
+          return res.status(400).json({ error: 'Invalid category' });
+        }
+        where.category = categoryParam;
       }
 
       const [total, products] = await prisma.$transaction([

--- a/backend/src/routes/webhook.ts
+++ b/backend/src/routes/webhook.ts
@@ -86,7 +86,7 @@ export function createWebhookRouter(prisma: PrismaClient) {
       const updatedStocks: { productId: number; stock: number }[] = [];
       await prisma.$transaction(async (tx) => {
         interface OrderWithItems {
-          items: { productId: number; qty: number }[];
+          items: { productId: number; quantity: number }[];
           userId?: string;
         }
         const order = (await tx.order.update({
@@ -100,8 +100,8 @@ export function createWebhookRouter(prisma: PrismaClient) {
         if (orderStatus === 'APPROVED') {
           for (const item of order.items) {
             const updated = await tx.product.updateMany({
-              where: { id: item.productId, stock: { gte: item.qty } },
-              data: { stock: { decrement: item.qty } },
+              where: { id: item.productId, stock: { gte: item.quantity } },
+              data: { stock: { decrement: item.quantity } },
             });
             if (updated.count === 0) {
               throw new Error(`Insufficient stock for product ${item.productId}`);

--- a/backend/test/checkout.integration.test.ts
+++ b/backend/test/checkout.integration.test.ts
@@ -91,7 +91,10 @@ describe('checkout create-order', () => {
     const res = await request(app)
       .post('/checkout/create-order')
       .send({
-        items: [{ productId: 1, qty: 2 }, { productId: 5, qty: 1 }],
+        items: [
+          { productId: 1, quantity: 2 },
+          { productId: 5, quantity: 1 },
+        ],
         zone: 'NORTE',
       })
       .expect(200);
@@ -102,15 +105,15 @@ describe('checkout create-order', () => {
     expect(prisma.createdOrder.total_cents).toBe(80400);
     expect(prisma.createdOrder.shipping_cents).toBe(500);
     expect(prisma.createdOrder.items.create).toEqual([
-      { productId: 1, qty: 2, unit_price_cents: 10000 },
-      { productId: 5, qty: 1, unit_price_cents: 59900 },
+      { productId: 1, quantity: 2, unitPriceCents: 10000 },
+      { productId: 5, quantity: 1, unitPriceCents: 59900 },
     ]);
   });
 
-  it('fails when qty exceeds stock', async () => {
+  it('fails when quantity exceeds stock', async () => {
     await request(app)
       .post('/checkout/create-order')
-      .send({ items: [{ productId: 1, qty: 5 }], zone: 'NORTE' })
+      .send({ items: [{ productId: 1, quantity: 5 }], zone: 'NORTE' })
       .expect(400);
     expect(prisma.createdOrder).toBeNull();
   });
@@ -122,8 +125,8 @@ describe('checkout create-preference', () => {
       id: 123,
       items: [
         {
-          qty: 2,
-          unit_price_cents: 10000,
+          quantity: 2,
+          unitPriceCents: 10000,
           product: { name: 'Prod 1' },
         },
       ],

--- a/backend/test/products.integration.test.ts
+++ b/backend/test/products.integration.test.ts
@@ -22,14 +22,19 @@ interface Product {
   currency: string;
   stock: number;
   image_url: string | null;
-  is_active: boolean;
+  status: string;
+  deleted: boolean;
+  category: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
 
 function matches(where: any, p: Product) {
-  if (where.is_active !== undefined && p.is_active !== where.is_active) return false;
+  if (where.id !== undefined && p.id !== where.id) return false;
+  if (where.status && p.status !== where.status) return false;
+  if (where.deleted !== undefined && p.deleted !== where.deleted) return false;
   if (where.slug && p.slug !== where.slug) return false;
+  if (where.category && p.category !== where.category) return false;
   if (where.OR) {
     const search = where.OR[0].name?.contains || where.OR[1].description?.contains;
     const s = String(search).toLowerCase();
@@ -51,7 +56,9 @@ class FakePrisma {
       currency: 'MXN',
       stock: 1,
       image_url: null,
-      is_active: true,
+      status: 'ACTIVE',
+      deleted: false,
+      category: 'cat1',
       createdAt: new Date(),
       updatedAt: new Date(),
     },
@@ -64,7 +71,9 @@ class FakePrisma {
       currency: 'MXN',
       stock: 2,
       image_url: null,
-      is_active: false,
+      status: 'INACTIVE',
+      deleted: false,
+      category: 'cat1',
       createdAt: new Date(),
       updatedAt: new Date(),
     },
@@ -77,7 +86,9 @@ class FakePrisma {
       currency: 'MXN',
       stock: 3,
       image_url: null,
-      is_active: true,
+      status: 'ACTIVE',
+      deleted: false,
+      category: 'cat2',
       createdAt: new Date(),
       updatedAt: new Date(),
     },
@@ -116,9 +127,15 @@ describe('products endpoints', () => {
     expect(res.body.data[0].name).toBe('Alpha');
   });
 
-  it('gets a product by slug', async () => {
-    const res = await request(app).get('/products/alpha').expect(200);
+  it('filters products by category', async () => {
+    const res = await request(app).get('/products?category=cat1').expect(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].slug).toBe('alpha');
+  });
+
+  it('gets a product by id', async () => {
+    const res = await request(app).get('/products/1').expect(200);
     expect(res.body.slug).toBe('alpha');
-    await request(app).get('/products/beta').expect(404);
+    await request(app).get('/products/2').expect(404);
   });
 });

--- a/backend/test/webhook.integration.test.ts
+++ b/backend/test/webhook.integration.test.ts
@@ -30,11 +30,11 @@ class FakePrisma {
   paymentEvent = {
     findUnique: vi.fn().mockResolvedValue(null),
     create: async ({ data }: any) => {
-      if (this.events.some((e) => e.mp_payment_id === data.mp_payment_id)) {
+      if (this.events.some((e) => e.eventId === data.eventId)) {
         throw new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
           code: 'P2002',
           clientVersion: '6.14.0',
-          meta: { target: ['mp_payment_id'] },
+          meta: { target: ['eventId'] },
         });
       }
       this.events.push(data);
@@ -71,13 +71,13 @@ describe('MercadoPago webhook', () => {
     await request(app)
       .post('/webhook/mercadopago')
       .set('X-Forwarded-For', '1.1.1.1')
-      .send({ data: { id: 'pay123' } })
+      .send({ id: 'evt1', data: { id: 'pay123' } })
       .expect(200);
 
     const res = await request(app)
       .post('/webhook/mercadopago')
       .set('X-Forwarded-For', '1.1.1.1')
-      .send({ data: { id: 'pay123' } })
+      .send({ id: 'evt1', data: { id: 'pay123' } })
       .expect(200);
 
     expect(res.body.status).toBe('ignored');
@@ -88,7 +88,7 @@ describe('MercadoPago webhook', () => {
     await request(app)
       .post('/webhook/mercadopago')
       .set('X-Forwarded-For', '2.2.2.2')
-      .send({ data: { id: 'pay321' } })
+      .send({ id: 'evt2', data: { id: 'pay321' } })
       .expect(403);
   });
 });

--- a/cypress/e2e/full-flow.cy.ts
+++ b/cypress/e2e/full-flow.cy.ts
@@ -24,7 +24,7 @@ describe('checkout flow', () => {
           cy.request({
             method: 'POST',
             url: `${api}/cart`,
-            body: { productId, qty: 1 },
+            body: { productId, quantity: 1 },
             headers: { Authorization: `Bearer ${token}` },
           })
             .its('status')
@@ -37,7 +37,7 @@ describe('checkout flow', () => {
           }).then((cartRes) => {
             const items = cartRes.body.items;
             expect(items).to.have.length(1);
-            expect(items[0]).to.include({ productId, qty: 1 });
+            expect(items[0]).to.include({ productId, quantity: 1 });
 
             cy.request({
               method: 'POST',

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -63,7 +63,7 @@ async function pay() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        items: cart.value.map((l) => ({ productId: l.productId, qty: l.qty })),
+        items: cart.value.map((l) => ({ productId: l.productId, quantity: l.qty })),
       }),
     });
     if (!orderRes.ok) throw new Error('Error creando orden');

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -99,7 +99,7 @@ async function pay() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        items: cart.value.map((l) => ({ productId: l.productId, qty: l.qty })),
+        items: cart.value.map((l) => ({ productId: l.productId, quantity: l.qty })),
         couponId: couponStore.coupon?.id,
         zone: selectedZone.value,
       }),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,9 +4,10 @@ import { quasar, transformAssetUrls } from '@quasar/vite-plugin';
 import prerender from 'vite-plugin-prerender';
 import { fetchProductRoutes } from '../scripts/fetchProductRoutes.js';
 
-export default defineConfig(async ({ mode }) => {
+export default defineConfig(async ({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), '');
-  const productRoutes = await fetchProductRoutes(env.VITE_API_URL);
+  const productRoutes =
+    command === 'build' ? await fetchProductRoutes(env.VITE_API_URL) : [];
 
   return {
     plugins: [

--- a/scripts/fetchProductRoutes.js
+++ b/scripts/fetchProductRoutes.js
@@ -8,10 +8,8 @@ export async function fetchProductRoutes(apiUrl) {
       console.error(`Failed to fetch products: ${res.status}`);
       return [];
     }
-    const products = await res.json();
-    if (!Array.isArray(products)) {
-      return [];
-    }
+    const json = await res.json();
+    const products = Array.isArray(json.data) ? json.data : [];
     return products.map((p) => `/product/${p.id}`);
   } catch (err) {
     console.error('Error fetching product routes:', err);


### PR DESCRIPTION
## Summary
- support category filtering in products API
- unify order item fields to quantity/unitPriceCents
- prerender home and product pages using backend product list

## Testing
- `npm test -w backend`
- `npm test -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68addbaf1c4083258e94a5b7c4e0d16a