### PR TITLE
feat: add order detail page

### DIFF
--- a/frontend/src/pages/OrderDetailPage.vue
+++ b/frontend/src/pages/OrderDetailPage.vue
@@ -1,0 +1,29 @@
+<template>
+  <q-page padding>
+    <div v-if="order">
+      <h1>Order {{ order.id }}</h1>
+      <p>Status: {{ order.status }}</p>
+    </div>
+    <div v-else>Loading...</div>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import axios from 'axios';
+
+interface Order {
+  id: number;
+  status: string;
+}
+
+const route = useRoute();
+const order = ref<Order | null>(null);
+
+onMounted(async () => {
+  const id = route.params.id as string;
+  const { data } = await axios.get(`/api/orders/${id}`);
+  order.value = data;
+});
+</script>

--- a/frontend/src/pages/ProductPage.vue
+++ b/frontend/src/pages/ProductPage.vue
@@ -16,14 +16,21 @@ import { useMeta } from 'quasar';
 import axios from 'axios';
 
 const route = useRoute();
-const product = ref<any>(null);
+interface Product {
+  id: number;
+  name: string;
+  description: string;
+  images?: { url: string }[];
+}
+
+const product = ref<Product | null>(null);
 
 const meta = ref({});
 useMeta(meta);
 
 onMounted(async () => {
-  const id = route.params.id as string;
-  const { data } = await axios.get(`/api/products/${id}`);
+  const slug = route.params.slug as string;
+  const { data } = await axios.get(`/api/products/${slug}`);
   product.value = data;
   meta.value = {
     title: data.name,

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -13,8 +13,17 @@ const routes: RouteRecordRaw[] = [
       { path: 'checkout/success', component: () => import('pages/CheckoutSuccessPage.vue') },
       { path: 'checkout/failure', component: () => import('pages/CheckoutFailurePage.vue') },
       { path: 'checkout/pending', component: () => import('pages/CheckoutPendingPage.vue') },
-      { path: 'orders', component: () => import('pages/OrdersPage.vue'), meta: { requiresAuth: true } },
-      { path: 'product/:id', component: () => import('pages/ProductPage.vue') },
+      {
+        path: 'orders',
+        component: () => import('pages/OrdersPage.vue'),
+        meta: { requiresAuth: true },
+      },
+      {
+        path: 'orders/:id',
+        component: () => import('pages/OrderDetailPage.vue'),
+        meta: { requiresAuth: true },
+      },
+      { path: 'product/:slug', component: () => import('pages/ProductPage.vue') },
     ],
   },
 


### PR DESCRIPTION
## Summary
- change product route to use slug and add order detail route
- add order detail page component
- update product page to fetch via slug

## Testing
- `npm run lint -w frontend` *(fails: @typescript-eslint/no-explicit-any in unrelated files)*
- `npx -w frontend eslint -c ./eslint.config.js src/router/routes.ts src/pages/ProductPage.vue src/pages/OrderDetailPage.vue`
- `npm test -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68addfcc76488325a0dc246587a4f5fe