### PR TITLE
feat: verify MercadoPago webhook signature

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,4 @@ JWT_SECRET=change-me
 JWT_EXPIRES_IN=7d
 MP_ACCESS_TOKEN=your-token
 MP_ALLOWED_IPS=1.2.3.4,5.6.7.8
+MP_PUBLIC_KEY=your-public-key

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,6 +18,7 @@
 - `JWT_EXPIRES_IN` — expiración del token (ej. `7d`)
 - `MP_ACCESS_TOKEN` — token de acceso de MercadoPago
 - `MP_ALLOWED_IPS` — IPs permitidas para webhooks de MercadoPago (separadas por coma)
+- `MP_PUBLIC_KEY` — clave pública para verificar las firmas de MercadoPago
 
 ## Seguridad
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -55,7 +55,13 @@ export function createApp(prisma: PrismaClient) {
       credentials: true,
     }),
   );
-  app.use(express.json());
+  app.use(
+    express.json({
+      verify: (req, _res, buf) => {
+        (req as express.Request & { rawBody?: string }).rawBody = buf.toString();
+      },
+    }),
+  );
 
   const authLimiter = rateLimit({
     windowMs: 60_000,

--- a/backend/src/routes/webhook.ts
+++ b/backend/src/routes/webhook.ts
@@ -4,9 +4,11 @@ import { Prisma, type PrismaClient } from '@prisma/client';
 import { MercadoPagoConfig, Payment } from 'mercadopago';
 import type { Logger } from 'pino';
 import type { Server } from 'socket.io';
+import crypto from 'crypto';
 
 interface RequestWithLog extends express.Request {
   log?: Logger;
+  rawBody?: string;
 }
 
 export function createWebhookRouter(prisma: PrismaClient) {
@@ -25,7 +27,28 @@ export function createWebhookRouter(prisma: PrismaClient) {
     next();
   };
 
+  const verifySignature = (header: string, rawBody: string, publicKey: string) => {
+    const match = header.match(/t=(\d+),v1=([^,]+)/);
+    if (!match) return false;
+    const [, timestamp, signature] = match;
+    try {
+      const verifier = crypto.createVerify('RSA-SHA256');
+      verifier.update(`${timestamp}.${rawBody}`);
+      verifier.end();
+      return verifier.verify(publicKey, Buffer.from(signature, 'base64'));
+    } catch {
+      return false;
+    }
+  };
+
   router.post('/mercadopago', allowlist, async (req: RequestWithLog, res) => {
+    const publicKey = process.env.MP_PUBLIC_KEY || '';
+    const signature = req.get('x-meli-signature') || '';
+    if (!publicKey || !verifySignature(signature, req.rawBody || '', publicKey)) {
+      req.log?.warn?.('Invalid MercadoPago signature');
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
     const eventId = req.body?.id ?? req.body?.eventId;
     const mpPaymentId = req.body?.data?.id ?? req.body?.mp_payment_id;
     if (!eventId || !mpPaymentId) {

--- a/backend/test/webhook.integration.test.ts
+++ b/backend/test/webhook.integration.test.ts
@@ -2,8 +2,10 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import type { PrismaClient } from '@prisma/client';
 import { Prisma } from '@prisma/client';
+import crypto from 'crypto';
 
 let createApp: typeof import('../src/app.js').createApp;
+let privateKey: string;
 
 process.env.JWT_SECRET = 'testsecret';
 process.env.MP_ACCESS_TOKEN = 'test';
@@ -58,6 +60,9 @@ let app: ReturnType<typeof createApp>;
 
 beforeAll(async () => {
   ({ createApp } = await import('../src/app.js'));
+  const { privateKey: pk, publicKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  privateKey = pk.export({ type: 'pkcs1', format: 'pem' }).toString();
+  process.env.MP_PUBLIC_KEY = publicKey.export({ type: 'pkcs1', format: 'pem' }).toString();
 });
 
 beforeEach(() => {
@@ -66,18 +71,36 @@ beforeEach(() => {
   app.set('trust proxy', 'loopback');
 });
 
+function signPayload(payload: any) {
+  const raw = JSON.stringify(payload);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const signature = crypto
+    .createSign('RSA-SHA256')
+    .update(`${timestamp}.${raw}`)
+    .end()
+    .sign(privateKey, 'base64');
+  return { raw, header: `t=${timestamp},v1=${signature}` };
+}
+
 describe('MercadoPago webhook', () => {
   it('ignores duplicate events on unique constraint error', async () => {
+    const payload = { id: 'evt1', data: { id: 'pay123' } };
+    let signed = signPayload(payload);
     await request(app)
       .post('/webhook/mercadopago')
       .set('X-Forwarded-For', '1.1.1.1')
-      .send({ id: 'evt1', data: { id: 'pay123' } })
+      .set('x-meli-signature', signed.header)
+      .set('Content-Type', 'application/json')
+      .send(signed.raw)
       .expect(200);
 
+    signed = signPayload(payload);
     const res = await request(app)
       .post('/webhook/mercadopago')
       .set('X-Forwarded-For', '1.1.1.1')
-      .send({ id: 'evt1', data: { id: 'pay123' } })
+      .set('x-meli-signature', signed.header)
+      .set('Content-Type', 'application/json')
+      .send(signed.raw)
       .expect(200);
 
     expect(res.body.status).toBe('ignored');
@@ -85,10 +108,27 @@ describe('MercadoPago webhook', () => {
   });
 
   it('blocks requests from non-allowlisted IPs', async () => {
+    const payload = { id: 'evt2', data: { id: 'pay321' } };
+    const signed = signPayload(payload);
     await request(app)
       .post('/webhook/mercadopago')
       .set('X-Forwarded-For', '2.2.2.2')
-      .send({ id: 'evt2', data: { id: 'pay321' } })
+      .set('x-meli-signature', signed.header)
+      .set('Content-Type', 'application/json')
+      .send(signed.raw)
+      .expect(403);
+  });
+
+  it('rejects requests with invalid signature', async () => {
+    const payload = { id: 'evt3', data: { id: 'pay000' } };
+    const raw = JSON.stringify(payload);
+    const timestamp = Math.floor(Date.now() / 1000);
+    await request(app)
+      .post('/webhook/mercadopago')
+      .set('X-Forwarded-For', '1.1.1.1')
+      .set('x-meli-signature', `t=${timestamp},v1=invalid`)
+      .set('Content-Type', 'application/json')
+      .send(raw)
       .expect(403);
   });
 });


### PR DESCRIPTION
## Summary
- verify MercadoPago webhook signatures using RSA and public key
- capture raw JSON body for signature verification
- test webhook signature handling and rejection of invalid signatures

## Testing
- `npm test -w backend test/webhook.integration.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68addfd03dd48325bc0f17c0d6c72d1b