### PR TITLE
Rename order approved status to confirmed

### DIFF
--- a/backend/prisma/migrations/20260215000000_rename_order_approved_to_confirmed/migration.sql
+++ b/backend/prisma/migrations/20260215000000_rename_order_approved_to_confirmed/migration.sql
@@ -1,0 +1,2 @@
+-- Rename existing orders with status APPROVED to CONFIRMED
+UPDATE "public"."Order" SET "status" = 'CONFIRMED' WHERE "status" = 'APPROVED';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,7 +15,7 @@ enum Role {
 
 enum OrderStatus {
   PENDING
-  APPROVED
+  CONFIRMED
   SHIPPED
   CANCELLED
 }

--- a/backend/src/routes/webhook.ts
+++ b/backend/src/routes/webhook.ts
@@ -54,7 +54,7 @@ export function createWebhookRouter(prisma: PrismaClient) {
         const status = String(req.body.payment_status || 'approved');
         switch (status) {
           case 'approved':
-            orderStatus = 'APPROVED';
+            orderStatus = 'CONFIRMED';
             break;
           case 'rejected':
             orderStatus = 'REJECTED';
@@ -71,7 +71,7 @@ export function createWebhookRouter(prisma: PrismaClient) {
         }
         switch (payment.status) {
           case 'approved':
-            orderStatus = 'APPROVED';
+            orderStatus = 'CONFIRMED';
             break;
           case 'rejected':
             orderStatus = 'REJECTED';
@@ -97,7 +97,7 @@ export function createWebhookRouter(prisma: PrismaClient) {
 
         userId = order.userId;
 
-        if (orderStatus === 'APPROVED') {
+        if (orderStatus === 'CONFIRMED') {
           for (const item of order.items) {
             const updated = await tx.product.updateMany({
               where: { id: item.productId, stock: { gte: item.quantity } },
@@ -127,7 +127,7 @@ export function createWebhookRouter(prisma: PrismaClient) {
 
       const io: Server | undefined = req.app.get('io');
       if (io) {
-        if (orderStatus === 'APPROVED' && userId) {
+        if (orderStatus === 'CONFIRMED' && userId) {
           io.to(`user:${userId}`).emit('order:statusChanged', {
             orderId,
             status: orderStatus,

--- a/cypress/e2e/full-flow.cy.ts
+++ b/cypress/e2e/full-flow.cy.ts
@@ -56,8 +56,8 @@ describe('checkout flow', () => {
                 .its('status')
                 .should('eq', 200);
 
-              // verify order status updated to APPROVED
-              cy.task('getOrder', orderId).its('status').should('eq', 'APPROVED');
+              // verify order status updated to CONFIRMED
+              cy.task('getOrder', orderId).its('status').should('eq', 'CONFIRMED');
             });
           });
         });

--- a/frontend/src/pages/admin/OrdersPage.vue
+++ b/frontend/src/pages/admin/OrdersPage.vue
@@ -14,7 +14,7 @@ import { ref } from 'vue';
 import { useOrdersStore } from 'src/stores/orders';
 
 const ordersStore = useOrdersStore();
-const statuses = ['PENDING','APPROVED','SHIPPED','CANCELLED'];
+const statuses = ['PENDING','CONFIRMED','SHIPPED','CANCELLED'];
 const columns = [
   { name: 'id', label: 'ID', field: 'id' },
   { name: 'status', label: 'Estado', field: 'status' },


### PR DESCRIPTION
## Summary
- rename OrderStatus APPROVED to CONFIRMED and migrate existing orders
- map MercadoPago approved payments to CONFIRMED in webhook
- show new CONFIRMED status on admin orders page and update e2e test

## Testing
- `npm run db:generate -w backend`
- `npm test -w backend` *(fails: EEXIST: file already exists, mkdir 'logs')*
- `npm test -w frontend`
- `npm run lint -w backend` *(fails: lint errors in source files)*
- `npm run lint -w frontend` *(fails: lint errors in source files)*
- `npm run e2e` *(fails: Cannot find package 'prom-client')*


------
https://chatgpt.com/codex/tasks/task_e_68addfd246388325bb6dab77d12e72b5