### PR TITLE
fix Prisma enum usage and add db scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,14 +8,14 @@
   },
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc -p .",
+    "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
     "format": "prettier . --check",
     "format:fix": "prettier . --write",
     "db:generate": "prisma generate",
-    "db:migrate": "prisma migrate dev --name init",
+    "db:migrate": "prisma migrate dev",
     "db:seed": "prisma db seed",
     "db:reset": "prisma migrate reset --force --skip-generate --skip-seed",
     "test": "vitest run"
@@ -39,6 +39,7 @@
     "passport-local": "^1.0.0",
     "pino": "^9.9.0",
     "pino-http": "^10.5.0",
+    "prom-client": "^15.1.3",
     "rotating-file-stream": "^3.2.7",
     "socket.io": "^4.7.5",
     "zod": "^3.23.8"

--- a/backend/src/routes/products.ts
+++ b/backend/src/routes/products.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { Prisma, type PrismaClient, ProductStatus } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 
 export function createProductsRouter(prisma: PrismaClient) {
   const router = express.Router();
@@ -13,7 +13,7 @@ export function createProductsRouter(prisma: PrismaClient) {
     try {
       const where: Prisma.ProductWhereInput = {
         deleted: false,
-        status: ProductStatus.ACTIVE,
+        status: Prisma.ProductStatus.ACTIVE,
       };
       if (search) {
         where.OR = [
@@ -48,7 +48,7 @@ export function createProductsRouter(prisma: PrismaClient) {
     const { slug } = req.params;
     try {
       const product = await prisma.product.findFirst({
-        where: { slug, deleted: false, status: ProductStatus.ACTIVE },
+        where: { slug, deleted: false, status: Prisma.ProductStatus.ACTIVE },
         include: { images: true },
       });
       if (!product) {
@@ -64,7 +64,7 @@ export function createProductsRouter(prisma: PrismaClient) {
     const { slug } = req.params;
     try {
       const product = await prisma.product.findFirst({
-        where: { slug, deleted: false, status: ProductStatus.ACTIVE },
+        where: { slug, deleted: false, status: Prisma.ProductStatus.ACTIVE },
         include: { images: { select: { url: true }, take: 1 } },
       });
       if (!product) {


### PR DESCRIPTION
## Summary
- add missing prom-client dependency and prisma scripts
- reference ProductStatus via Prisma enum

## Testing
- `npx prisma generate`
- `curl -s http://localhost:3000/api/health`
- `npm test` *(fails: expected 200 "OK", got 500 "Internal Server Error")*

------
https://chatgpt.com/codex/tasks/task_e_68b20f0caff48325b6027d35ad66ae2b