### PR TITLE
Add health check endpoint and centralize product typing

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -153,6 +153,16 @@ app.use((req, res, next) => {
   next();
 });
 
+// Basic health check endpoint
+app.get('/health', async (_req, res) => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    res.json({ status: 'ok', db: 'connected' });
+  } catch {
+    res.json({ status: 'ok', db: 'disconnected' });
+  }
+});
+
 app.use('/api/health', createHealthRouter());
 app.use('/api/metrics', createMetricsRouter(register));
 app.use('/api/auth', authLimiter, createAuthRouter(prisma));

--- a/frontend/src/components/ProductCard.vue
+++ b/frontend/src/components/ProductCard.vue
@@ -24,7 +24,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import type { Product } from 'src/stores/productsStore';
+import type { Product } from 'src/types/product';
 
 const props = defineProps<{ product: Product }>();
 const emit = defineEmits<{ (e: 'add', product: Product): void }>();

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -6,7 +6,7 @@
     <div v-else class="column q-gutter-y-md">
       <div
         v-for="line in cart"
-        :key="line.lineId"
+        :key="line.productId"
         class="row items-center q-gutter-x-md"
       >
         <img :src="line.image_url" alt="" class="cart-image" />
@@ -20,14 +20,14 @@
           min="1"
           :max="line.stock"
           style="width: 80px"
-          @update:model-value="(val) => cartStore.updateQty(line.lineId, Number(val))"
+          @update:model-value="(val) => cartStore.updateQty(line.productId, Number(val))"
         />
         <q-btn
           dense
           flat
           icon="delete"
           color="negative"
-          @click="cartStore.remove(line.lineId)"
+          @click="cartStore.remove(line.productId)"
         />
       </div>
       <div class="text-right q-mt-lg">

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -6,7 +6,7 @@
     <div v-else class="column q-gutter-y-md">
       <div
         v-for="line in cart"
-        :key="line.lineId"
+        :key="line.productId"
         class="row items-center q-gutter-x-md"
       >
         <img :src="line.image_url" alt="" class="cart-image" />

--- a/frontend/src/pages/ProductPage.vue
+++ b/frontend/src/pages/ProductPage.vue
@@ -16,10 +16,9 @@ import { useMeta } from 'quasar';
 import axios from 'axios';
 
 const route = useRoute();
-interface Product {
-  id: number;
-  name: string;
-  description: string;
+import type { Product as BaseProduct } from 'src/types/product';
+
+interface Product extends BaseProduct {
   images?: { url: string }[];
 }
 

--- a/frontend/src/stores/product.ts
+++ b/frontend/src/stores/product.ts
@@ -1,15 +1,5 @@
 import { defineStore } from 'pinia';
-
-export interface Product {
-  id: number;
-  name: string;
-  slug: string;
-  description?: string;
-  price_cents: number;
-  currency: string;
-  stock: number;
-  image_url?: string;
-}
+import type { Product } from 'src/types/product';
 
 interface Filters {
   search: string;

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -1,0 +1,10 @@
+export interface Product {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string;
+  price_cents: number;
+  currency: string;
+  stock: number;
+  image_url?: string;
+}


### PR DESCRIPTION
## Summary
- expose unauthenticated `/health` endpoint with optional DB connectivity check
- centralize Product interface and update components to use it
- fix cart and checkout pages to reference `productId`

## Testing
- `npm test` *(fails: vitest not found)*
- `npx --yes vitest@1.6.0 run` *(backend tests missing dependencies: supertest, bcryptjs, jsonwebtoken)*
- `cd frontend && npx --yes vitest@3.2.4 run`
- `npx --yes tsc -p tsconfig.json --noEmit` *(frontend type check missing deps)*
- `DATABASE_URL="postgresql://localhost:5432/postgres" npx --yes tsx backend/src/index.ts` *(server failed: Cannot find package 'passport')*

------
https://chatgpt.com/codex/tasks/task_e_68b2137a9ca48325864381b48fc0fbee