### PR TITLE
feat: centralize product API client

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+});

--- a/frontend/src/components/ProductList.vue
+++ b/frontend/src/components/ProductList.vue
@@ -27,9 +27,9 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import ProductCard from './ProductCard.vue';
-import { useProductsStore } from 'src/stores/productsStore';
+import { useProductStore } from 'stores/product';
 
-const store = useProductsStore();
+const store = useProductStore();
 const page = ref(1);
 const limit = 12;
 

--- a/frontend/src/components/ProductSearch.vue
+++ b/frontend/src/components/ProductSearch.vue
@@ -29,7 +29,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from 'vue';
-import { useProductsStore } from 'src/stores/productsStore';
+import { useProductStore } from 'stores/product';
 
 interface CategoryOption {
   label: string;
@@ -42,7 +42,7 @@ interface Props {
 
 defineProps<Props>();
 
-const store = useProductsStore();
+const store = useProductStore();
 
 const search = ref(store.filters.search);
 const category = ref(store.filters.category);

--- a/frontend/src/pages/HomePage.vue
+++ b/frontend/src/pages/HomePage.vue
@@ -22,11 +22,11 @@
 import { computed, onMounted } from 'vue';
 import ProductSearch from 'components/ProductSearch.vue';
 import ProductCard from 'components/ProductCard.vue';
-import { useProductStore } from 'stores/product'; // 👈 usar el store correcto
+import { useProductStore } from 'stores/product';
 import { useCartStore } from 'stores/cart';
 import type { Product } from 'src/types/product';
 
-const productStore = useProductStore(); // 👈 este es el de catálogo
+const productStore = useProductStore();
 const cartStore = useCartStore();
 
 const products = computed(() =>

--- a/frontend/src/pages/ProductPage.vue
+++ b/frontend/src/pages/ProductPage.vue
@@ -13,7 +13,7 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { useMeta } from 'quasar';
-import axios from 'axios';
+import { api } from 'src/api/api';
 
 const route = useRoute();
 import type { Product as BaseProduct } from 'src/types/product';
@@ -30,8 +30,7 @@ useMeta(() => ({ title: product.value?.name || 'Producto' }));
 
 onMounted(async () => {
   const slug = route.params.slug as string;
-const baseUrl = import.meta.env.VITE_API_URL;
-const { data } = await axios.get(`${baseUrl}/api/products/${slug}`);
+const { data } = await api.get(`/api/products/${slug}`);
   product.value = data;
 });
 </script>

--- a/frontend/src/stores/product.ts
+++ b/frontend/src/stores/product.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia';
+import { api } from 'src/api/api';
 import type { Product } from 'src/types/product';
 
 interface Filters {
@@ -53,20 +54,14 @@ export const useProductStore = defineStore('products', {
         this.error = null;
       }
       try {
-        const params = new URLSearchParams({
-          page: page.toString(),
-          limit: limit.toString(),
-        });
-        if (this.filters.search) params.append('search', this.filters.search);
-        if (this.filters.category) params.append('category', this.filters.category);
+        const params: Record<string, string | number> = {
+          page,
+          limit,
+        };
+        if (this.filters.search) params.search = this.filters.search;
+        if (this.filters.category) params.category = this.filters.category;
 
-        // 👇 usar la variable de entorno
-        const baseUrl = import.meta.env.VITE_API_URL;
-        const res = await fetch(`${baseUrl}/api/products?${params.toString()}`);
-
-
-        if (!res.ok) throw new Error('Failed to fetch products');
-        const json = await res.json();
+        const { data: json } = await api.get('/api/products', { params });
         this.pages[page] = json.data as Product[];
         this.total = json.meta.total;
       } catch (err: unknown) {
@@ -89,5 +84,3 @@ export const useProductStore = defineStore('products', {
     },
   },
 });
-
-export const useProductsStore = useProductStore;

--- a/frontend/src/stores/products.ts
+++ b/frontend/src/stores/products.ts
@@ -1,14 +1,12 @@
 import { defineStore } from 'pinia';
-import axios from 'axios';
+import { api } from 'src/api/api';
 import type { Product } from 'src/types/product';
-
-const baseUrl = import.meta.env.VITE_API_URL;
 
 export const useProductsStore = defineStore('adminProducts', {
   state: () => ({ products: [] as Product[] }),
   actions: {
     async fetch() {
-      const { data } = await axios.get(`${baseUrl}/api/admin/products`);
+      const { data } = await api.get('/api/admin/products');
       this.products = data;
     },
     async save(product: Partial<Product>, images: File[]) {
@@ -19,19 +17,19 @@ export const useProductsStore = defineStore('adminProducts', {
       images.forEach((img) => form.append('images', img));
 
       if (product.id) {
-        await axios.put(`${baseUrl}/api/admin/products/${product.id}`, form);
+        await api.put(`/api/admin/products/${product.id}`, form);
       } else {
-        await axios.post(`${baseUrl}/api/admin/products`, form);
+        await api.post('/api/admin/products', form);
       }
 
       await this.fetch();
     },
     async updateStock(id: number, stock: number) {
-      await axios.patch(`${baseUrl}/api/admin/products/${id}/stock`, { stock });
+      await api.patch(`/api/admin/products/${id}/stock`, { stock });
       await this.fetch();
     },
     async delete(id: number) {
-      await axios.delete(`${baseUrl}/api/admin/products/${id}`);
+      await api.delete(`/api/admin/products/${id}`);
       await this.fetch();
     },
   },

--- a/frontend/src/stores/productsStore.ts
+++ b/frontend/src/stores/productsStore.ts
@@ -1,1 +1,0 @@
-export { useProductStore as useProductsStore } from './product';


### PR DESCRIPTION
## Summary
- add shared axios client tied to VITE_API_URL
- refactor product and admin product stores to use centralized client
- drop deprecated productsStore imports in components and pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b250a69cfc8325b8536acb558d9e45