### PR TITLE
Normalize price fields for products and cart

### DIFF
--- a/frontend/src/stores/cart.ts
+++ b/frontend/src/stores/cart.ts
@@ -20,7 +20,15 @@ export const useCartStore = defineStore('cart', () => {
 
   // LocalStorage
   function loadLocal() {
-    cart.value = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    cart.value = raw.map((item: any) => {
+      const price = item.price_cents ?? item.priceCents ?? 0;
+      const { priceCents, price_cents, ...rest } = item;
+      return {
+        ...rest,
+        price_cents: price,
+      } as CartItem;
+    });
   }
 
   function persistLocal() {
@@ -33,10 +41,14 @@ export const useCartStore = defineStore('cart', () => {
       headers: { Authorization: `Bearer ${auth.token}` },
     });
 
-    cart.value = (data.items ?? []).map((item: any) => ({
-      ...item,
-      price_cents: item.price_cents ?? item.priceCents ?? 0,
-    }));
+    cart.value = (data.items ?? []).map((item: any) => {
+      const price = item.price_cents ?? item.priceCents ?? 0;
+      const { priceCents, price_cents, ...rest } = item;
+      return {
+        ...rest,
+        price_cents: price,
+      } as CartItem;
+    });
   }
 
   // Fusionar carrito local al remoto

--- a/frontend/src/stores/product.ts
+++ b/frontend/src/stores/product.ts
@@ -70,10 +70,14 @@ export const useProductStore = defineStore('products', {
         console.log('FETCHED PRODUCTS RAW:', json);
 
         // 👇 Normalizamos para aceptar tanto priceCents (backend) como price_cents
-        this.pages[page] = (json.data as Product[]).map((p: any) => ({
-          ...p,
-          priceCents: p.priceCents ?? p.price_cents ?? 0,
-        }));
+        this.pages[page] = (json.data as any[]).map((p) => {
+          const price = p.price_cents ?? p.priceCents ?? 0;
+          return {
+            ...p,
+            price_cents: price,
+            priceCents: price,
+          } as Product;
+        });
 
         this.total = json.data.length;
 

--- a/frontend/src/types/cart.ts
+++ b/frontend/src/types/cart.ts
@@ -1,7 +1,8 @@
 export interface CartItem {
   productId: number;
   name: string;
-  price_cents: number;
+  price_cents?: number;
+  priceCents?: number;
   currency: string;
   qty: number;
   stock: number;

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -3,7 +3,8 @@ export interface Product {
   name: string;
   slug: string;
   description?: string;
-  price_cents: number;
+  price_cents?: number;
+  priceCents?: number;
   currency: string;
   stock: number;
   image_url?: string;


### PR DESCRIPTION
## Summary
- support both snake_case and camelCase price fields in Product and CartItem types
- map backend product responses to include both price_cents and priceCents
- normalize cart to always use price_cents and avoid NaN totals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3661efa4c8325be0083a7f1c3d707