### PR TITLE
Fix cart subtotal and total with price normalization

### DIFF
--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -12,7 +12,10 @@
         <img v-if="line.image_url" :src="line.image_url" alt="" class="cart-image" />
         <div class="col">
           <div class="text-weight-medium">{{ line.name }}</div>
-          <div>{{ (line.price_cents / 100).toFixed(2) }} {{ line.currency }}</div>
+          <div>
+            {{ ((line.price_cents ?? 0) / 100).toFixed(2) }}
+            {{ line.currency ?? 'USD' }}
+          </div>
         </div>
         <q-input
           type="number"
@@ -32,10 +35,12 @@
       </div>
       <div class="text-right q-mt-lg">
         <div>
-          Subtotal: {{ (subtotal / 100).toFixed(2) }} {{ currency }}
+          Subtotal: {{ ((subtotal ?? 0) / 100).toFixed(2) }}
+          {{ currency }}
         </div>
         <div>
-          Total: {{ (total / 100).toFixed(2) }} {{ currency }}
+          Total: {{ ((total ?? 0) / 100).toFixed(2) }}
+          {{ currency }}
         </div>
         <q-btn color="primary" label="Pagar" class="q-mt-md" @click="async () => { await pay(); }" />
       </div>
@@ -52,7 +57,7 @@ const cartStore = useCartStore();
 const cart = computed(() => cartStore.cart);
 const subtotal = computed(() => cartStore.subtotal);
 const total = computed(() => cartStore.total);
-const currency = computed(() => cart.value[0]?.currency || 'USD');
+const currency = computed(() => cart.value[0]?.currency ?? 'USD');
 const $q = useQuasar();
 const apiBase =
   import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL;

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -12,7 +12,10 @@
         <img v-if="line.image_url" :src="line.image_url" alt="" class="cart-image" />
         <div class="col">
           <div class="text-weight-medium">{{ line.name }}</div>
-          <div>{{ (line.price_cents / 100).toFixed(2) }} {{ line.currency }}</div>
+          <div>
+            {{ ((line.price_cents ?? 0) / 100).toFixed(2) }}
+            {{ line.currency ?? 'MXN' }}
+          </div>
         </div>
         <div>x{{ line.qty }}</div>
       </div>
@@ -28,13 +31,17 @@
       />
 
       <div class="text-right q-mt-lg">
-        <div>Subtotal: {{ (subtotal / 100).toFixed(2) }} {{ currency }}</div>
-        <div v-if="couponStore.coupon">
-          Descuento: -{{ (discount / 100).toFixed(2) }} {{ currency }}
-        </div>
-        <div>Envío: {{ (shippingCost / 100).toFixed(2) }} {{ currency }}</div>
         <div>
-          Total: {{ (total / 100).toFixed(2) }} {{ currency }}
+          Subtotal: {{ ((subtotal ?? 0) / 100).toFixed(2) }} {{ currency }}
+        </div>
+        <div v-if="couponStore.coupon">
+          Descuento: -{{ ((discount ?? 0) / 100).toFixed(2) }} {{ currency }}
+        </div>
+        <div>
+          Envío: {{ ((shippingCost ?? 0) / 100).toFixed(2) }} {{ currency }}
+        </div>
+        <div>
+          Total: {{ ((total ?? 0) / 100).toFixed(2) }} {{ currency }}
         </div>
         <CheckoutButton class="q-mt-md" @click="async () => { await pay(); }" />
       </div>
@@ -55,12 +62,12 @@ const couponStore = useCouponStore();
 const shippingStore = useShippingStore();
 const cart = computed(() => cartStore.cart);
 const subtotal = computed(() => cartStore.subtotal);
-const discount = computed(() => couponStore.coupon?.discount || 0);
-const shippingCost = computed(() => shippingStore.cost);
+const discount = computed(() => couponStore.coupon?.discount ?? 0);
+const shippingCost = computed(() => shippingStore.cost ?? 0);
 const total = computed(
   () => subtotal.value - discount.value + shippingCost.value,
 );
-const currency = computed(() => cart.value[0]?.currency || 'MXN');
+const currency = computed(() => cart.value[0]?.currency ?? 'MXN');
 
 const couponCode = ref('');
 const selectedZone = ref('');

--- a/frontend/src/stores/cart.ts
+++ b/frontend/src/stores/cart.ts
@@ -14,18 +14,25 @@ export const useCartStore = defineStore('cart', () => {
 
   // Subtotal y total siempre calculados con price_cents
   const subtotal = computed(() =>
-    cart.value.reduce((sum, line) => sum + line.price_cents * line.qty, 0),
+    cart.value.reduce(
+      (sum, line) => sum + (line.price_cents ?? 0) * line.qty,
+      0,
+    ),
   );
-  const total = subtotal;
+  const total = computed(() => subtotal.value);
 
   // LocalStorage
   function loadLocal() {
-    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
-    cart.value = raw.map((item: any) => {
-      const price = item.price_cents ?? item.priceCents ?? 0;
-      const { priceCents, price_cents, ...rest } = item;
+    const raw = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? '[]',
+    ) as Array<Partial<CartItem>>;
+    cart.value = raw.map((item) => {
+      const obj = { ...item } as Partial<CartItem>;
+      const price = obj.price_cents ?? obj.priceCents ?? 0;
+      delete obj.priceCents;
+      delete obj.price_cents;
       return {
-        ...rest,
+        ...obj,
         price_cents: price,
       } as CartItem;
     });
@@ -41,11 +48,14 @@ export const useCartStore = defineStore('cart', () => {
       headers: { Authorization: `Bearer ${auth.token}` },
     });
 
-    cart.value = (data.items ?? []).map((item: any) => {
-      const price = item.price_cents ?? item.priceCents ?? 0;
-      const { priceCents, price_cents, ...rest } = item;
+    const items = (data.items ?? []) as Array<Partial<CartItem>>;
+    cart.value = items.map((item) => {
+      const obj = { ...item } as Partial<CartItem>;
+      const price = obj.price_cents ?? obj.priceCents ?? 0;
+      delete obj.priceCents;
+      delete obj.price_cents;
       return {
-        ...rest,
+        ...obj,
         price_cents: price,
       } as CartItem;
     });

--- a/frontend/src/stores/product.ts
+++ b/frontend/src/stores/product.ts
@@ -70,7 +70,8 @@ export const useProductStore = defineStore('products', {
         console.log('FETCHED PRODUCTS RAW:', json);
 
         // 👇 Normalizamos para aceptar tanto priceCents (backend) como price_cents
-        this.pages[page] = (json.data as any[]).map((p) => {
+        const data = json.data as Array<Partial<Product>>;
+        this.pages[page] = data.map((p) => {
           const price = p.price_cents ?? p.priceCents ?? 0;
           return {
             ...p,

--- a/frontend/src/types/cart.ts
+++ b/frontend/src/types/cart.ts
@@ -1,7 +1,7 @@
 export interface CartItem {
   productId: number;
   name: string;
-  price_cents?: number;
+  price_cents: number;
   priceCents?: number;
   currency: string;
   qty: number;


### PR DESCRIPTION
## Summary
- normalize cart items to `price_cents`
- handle both `priceCents` and `price_cents` on product and cart items
- fix cart and checkout pages to avoid NaN totals

## Testing
- `npm test -w frontend`
- `npm test`
- `npm run lint -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b368c5a56c8325b26482888a785f43