### PR TITLE
fix(frontend): unify priceCents usage

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
         async createProduct(data: {
           name: string;
           slug: string;
-          price_cents: number;
+          priceCents: number;
           stock?: number;
         }) {
           return prisma.product.create({ data });

--- a/cypress/e2e/full-flow.cy.ts
+++ b/cypress/e2e/full-flow.cy.ts
@@ -9,7 +9,7 @@ describe('checkout flow', () => {
     cy.task('createProduct', {
       name: 'Test Product',
       slug: `test-product-${Date.now()}`,
-      price_cents: 500,
+      priceCents: 500,
       stock: 10,
     }).then((product) => {
       const productId = product.id;

--- a/frontend/src/components/ProductCard.vue
+++ b/frontend/src/components/ProductCard.vue
@@ -32,14 +32,12 @@ type ProductImage = { url: string };
 /**
  * Acepta ambos formatos de backend:
  * - camelCase: priceCents, imageUrl, images[]
- * - snake_case: price_cents, image_url
+ * - snake_case: image_url
  */
 type ProductView = BaseProduct & {
   images?: ProductImage[];
   image_url?: string;
   imageUrl?: string;
-  price_cents?: number;
-  priceCents?: number;       // 👈 añadido para que TS no marque error
   currency?: string | null;
 };
 
@@ -54,10 +52,7 @@ const mainImage = computed(() =>
 );
 
 const formattedPrice = computed(() => {
-  const cents =
-    props.product.priceCents ??
-    props.product.price_cents ??
-    0;
+  const cents = props.product.priceCents ?? 0;
   const price = cents / 100;
   const currency = props.product.currency ?? 'MXN';
   return new Intl.NumberFormat('es-MX', { style: 'currency', currency }).format(price);

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -13,7 +13,7 @@
         <div class="col">
           <div class="text-weight-medium">{{ line.name }}</div>
           <div>
-            {{ ((line.price_cents ?? 0) / 100).toFixed(2) }}
+            {{ ((line.priceCents * line.qty) / 100).toFixed(2) }}
             {{ line.currency ?? 'USD' }}
           </div>
         </div>
@@ -35,11 +35,11 @@
       </div>
       <div class="text-right q-mt-lg">
         <div>
-          Subtotal: {{ ((subtotal ?? 0) / 100).toFixed(2) }}
+          Subtotal: {{ (subtotal / 100).toFixed(2) }}
           {{ currency }}
         </div>
         <div>
-          Total: {{ ((total ?? 0) / 100).toFixed(2) }}
+          Total: {{ (total / 100).toFixed(2) }}
           {{ currency }}
         </div>
         <q-btn color="primary" label="Pagar" class="q-mt-md" @click="async () => { await pay(); }" />

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -13,7 +13,7 @@
         <div class="col">
           <div class="text-weight-medium">{{ line.name }}</div>
           <div>
-            {{ ((line.price_cents ?? 0) / 100).toFixed(2) }}
+            {{ ((line.priceCents * line.qty) / 100).toFixed(2) }}
             {{ line.currency ?? 'MXN' }}
           </div>
         </div>
@@ -32,16 +32,16 @@
 
       <div class="text-right q-mt-lg">
         <div>
-          Subtotal: {{ ((subtotal ?? 0) / 100).toFixed(2) }} {{ currency }}
+          Subtotal: {{ (subtotal / 100).toFixed(2) }} {{ currency }}
         </div>
         <div v-if="couponStore.coupon">
-          Descuento: -{{ ((discount ?? 0) / 100).toFixed(2) }} {{ currency }}
+          Descuento: -{{ (discount / 100).toFixed(2) }} {{ currency }}
         </div>
         <div>
-          Envío: {{ ((shippingCost ?? 0) / 100).toFixed(2) }} {{ currency }}
+          Envío: {{ (shippingCost / 100).toFixed(2) }} {{ currency }}
         </div>
         <div>
-          Total: {{ ((total ?? 0) / 100).toFixed(2) }} {{ currency }}
+          Total: {{ (total / 100).toFixed(2) }} {{ currency }}
         </div>
         <CheckoutButton class="q-mt-md" @click="async () => { await pay(); }" />
       </div>

--- a/frontend/src/pages/admin/ProductsPage.vue
+++ b/frontend/src/pages/admin/ProductsPage.vue
@@ -12,7 +12,7 @@
       <q-card style="min-width:400px">
         <q-card-section>
           <q-input v-model="form.name" label="Nombre" />
-          <q-input v-model.number="form.price_cents" label="Precio (cents)" />
+          <q-input v-model.number="form.priceCents" label="Precio (cents)" />
           <q-input v-model.number="form.stock" label="Stock" />
           <q-input v-model="form.category" label="Categoría" />
           <q-select v-model="form.status" :options="statusOptions" label="Estado" />
@@ -42,7 +42,7 @@ interface AdminProduct extends Product {
 
 const columns = [
   { name: 'name', label: 'Nombre', field: 'name' },
-  { name: 'price', label: 'Precio', field: 'price_cents', format: (v: number) => `$${(v / 100).toFixed(2)}` },
+  { name: 'price', label: 'Precio', field: 'priceCents', format: (v: number) => `$${(v / 100).toFixed(2)}` },
   { name: 'stock', label: 'Stock', field: 'stock' },
   { name: 'status', label: 'Estado', field: 'status' },
   { name: 'actions', label: 'Acciones', field: (row: Product) => row.id }

--- a/frontend/src/stores/cart.ts
+++ b/frontend/src/stores/cart.ts
@@ -12,12 +12,9 @@ export const useCartStore = defineStore('cart', () => {
   const auth = useAuthStore();
   const cart = ref<CartItem[]>([]);
 
-  // Subtotal y total siempre calculados con price_cents
+  // Subtotal y total siempre calculados con priceCents
   const subtotal = computed(() =>
-    cart.value.reduce(
-      (sum, line) => sum + (line.price_cents ?? 0) * line.qty,
-      0,
-    ),
+    cart.value.reduce((sum, line) => sum + line.priceCents * line.qty, 0),
   );
   const total = computed(() => subtotal.value);
 
@@ -26,39 +23,25 @@ export const useCartStore = defineStore('cart', () => {
     const raw = JSON.parse(
       localStorage.getItem(STORAGE_KEY) ?? '[]',
     ) as Array<Partial<CartItem>>;
-    cart.value = raw.map((item) => {
-      const obj = { ...item } as Partial<CartItem>;
-      const price = obj.price_cents ?? obj.priceCents ?? 0;
-      delete obj.priceCents;
-      delete obj.price_cents;
-      return {
-        ...obj,
-        price_cents: price,
-      } as CartItem;
-    });
+    cart.value = raw.map(
+      (item) => ({ ...item, priceCents: item.priceCents ?? 0 } as CartItem),
+    );
   }
 
   function persistLocal() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(cart.value));
   }
 
-  // Cargar carrito remoto y normalizar a price_cents
+  // Cargar carrito remoto
   async function fetchRemote() {
     const { data } = await api.get('/api/cart', {
       headers: { Authorization: `Bearer ${auth.token}` },
     });
 
     const items = (data.items ?? []) as Array<Partial<CartItem>>;
-    cart.value = items.map((item) => {
-      const obj = { ...item } as Partial<CartItem>;
-      const price = obj.price_cents ?? obj.priceCents ?? 0;
-      delete obj.priceCents;
-      delete obj.price_cents;
-      return {
-        ...obj,
-        price_cents: price,
-      } as CartItem;
-    });
+    cart.value = items.map(
+      (item) => ({ ...item, priceCents: item.priceCents ?? 0 } as CartItem),
+    );
   }
 
   // Fusionar carrito local al remoto
@@ -100,8 +83,7 @@ export const useCartStore = defineStore('cart', () => {
         cart.value.push({
           productId: product.id,
           name: product.name,
-          // 👇 siempre convertimos a snake_case para el carrito
-          price_cents: product.price_cents ?? product.priceCents ?? 0,
+          priceCents: product.priceCents,
           currency: product.currency ?? 'USD',
           qty,
           stock: product.stock,

--- a/frontend/src/stores/product.ts
+++ b/frontend/src/stores/product.ts
@@ -69,16 +69,10 @@ export const useProductStore = defineStore('products', {
         const { data: json } = await api.get('/api/products', { params });
         console.log('FETCHED PRODUCTS RAW:', json);
 
-        // 👇 Normalizamos para aceptar tanto priceCents (backend) como price_cents
         const data = json.data as Array<Partial<Product>>;
-        this.pages[page] = data.map((p) => {
-          const price = p.price_cents ?? p.priceCents ?? 0;
-          return {
-            ...p,
-            price_cents: price,
-            priceCents: price,
-          } as Product;
-        });
+        this.pages[page] = data.map(
+          (p) => ({ ...p, priceCents: p.priceCents ?? 0 } as Product),
+        );
 
         this.total = json.data.length;
 

--- a/frontend/src/types/cart.ts
+++ b/frontend/src/types/cart.ts
@@ -1,8 +1,7 @@
 export interface CartItem {
   productId: number;
   name: string;
-  price_cents: number;
-  priceCents?: number;
+  priceCents: number;
   currency: string;
   qty: number;
   stock: number;

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -3,8 +3,7 @@ export interface Product {
   name: string;
   slug: string;
   description?: string;
-  price_cents?: number;
-  priceCents?: number;
+  priceCents: number;
   currency: string;
   stock: number;
   image_url?: string;


### PR DESCRIPTION
## Summary
- use `priceCents` consistently across product and cart types
- update cart and product stores and pages to compute totals from `priceCents`
- adjust tests and admin page for camelCase price

## Testing
- `npm test`
- `npm run lint -w frontend`
- `npm run build -w frontend` *(fails: Identifier expected in @vitejs/plugin-vue)*

------
https://chatgpt.com/codex/tasks/task_e_68b36c072bbc8325aeb111b41acc28d5