### PR TITLE
feat: add checkout endpoint using MercadoPago

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -27,6 +27,8 @@ import { createReviewsRouter } from './routes/reviews.js';
 import { createCouponsRouter } from './routes/coupons.js';
 // eslint-disable-next-line import/no-unresolved
 import { createShippingRouter } from './routes/shipping.js';
+// eslint-disable-next-line import/no-unresolved
+import checkoutRouter from './routes/checkout.js';
 
 interface RequestWithLog extends express.Request {
   log?: Logger;
@@ -154,6 +156,7 @@ export function createApp(prisma: PrismaClient) {
   app.use('/products', createProductsRouter(prisma));
   app.use('/api/orders', createOrdersRouter(prisma));
   app.use('/checkout', createOrdersRouter(prisma));
+  app.use('/api/checkout', checkoutRouter);
   app.use('/webhook/mercadopago', webhookLimiter);
   app.use('/webhook', createWebhookRouter(prisma));
   app.use('/admin/reviews', createReviewsRouter(prisma));

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,0 +1,60 @@
+import express from 'express';
+
+interface CheckoutItem {
+  title: string;
+  quantity: number;
+  unit_price: number;
+}
+
+const checkoutRouter = express.Router();
+
+checkoutRouter.post('/create-order', async (req, res) => {
+  try {
+    const items = req.body as CheckoutItem[];
+    if (!Array.isArray(items) || items.length === 0) {
+      return res.status(400).json({ success: false, error: 'No items provided' });
+    }
+
+    const mp = await import('mercadopago');
+
+    let preferenceId: string;
+    let initPoint: string;
+
+    if ('preferences' in mp) {
+      (mp as any).configure?.({ access_token: process.env.MP_ACCESS_TOKEN ?? '' });
+      const preference = await (mp as any).preferences.create({
+        items,
+        back_urls: {
+          success: 'http://localhost:9000/success',
+          failure: 'http://localhost:9000/failure',
+          pending: 'http://localhost:9000/pending',
+        },
+      });
+      preferenceId = preference.body?.id ?? preference.id;
+      initPoint = preference.body?.init_point ?? preference.init_point;
+    } else {
+      const client = new (mp as any).MercadoPagoConfig({
+        accessToken: process.env.MP_ACCESS_TOKEN ?? '',
+      });
+      const preferenceClient = new (mp as any).Preference(client);
+      const preference = await preferenceClient.create({
+        body: {
+          items,
+          back_urls: {
+            success: 'http://localhost:9000/success',
+            failure: 'http://localhost:9000/failure',
+            pending: 'http://localhost:9000/pending',
+          },
+        },
+      });
+      preferenceId = preference.id;
+      initPoint = preference.init_point;
+    }
+
+    return res.json({ success: true, preferenceId, init_point: initPoint });
+  } catch (error) {
+    return res.status(500).json({ success: false, error: 'Error creando orden' });
+  }
+});
+
+export default checkoutRouter;


### PR DESCRIPTION
## Summary
- add checkout API route to create MercadoPago orders
- wire checkout router into Express app

## Testing
- `npm test` *(fails: expected 200 "OK", got 500 "Internal Server Error")*
- `npm run lint` *(fails: eslint command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b3aacd229c832599d83e4500a76259