### PR TITLE
chore: proxy API requests

### DIFF
--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -81,6 +81,12 @@ export default defineConfig((/* ctx */) => {
     devServer: {
       // https: true,
       open: true, // opens browser window automatically
+      proxy: {
+        '/api': {
+          target: 'http://localhost:3000',
+          changeOrigin: true,
+        },
+      },
     },
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#framework

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
 export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_API_URL || '',
 });


### PR DESCRIPTION
## Summary
- proxy front-end /api calls to Express backend
- default axios base URL to ensure relative API requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4cc0fbdb08325b3a8433ce2a334ce