### PR TITLE
Fix checkout proxy rewrite

### DIFF
--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -85,6 +85,8 @@ export default defineConfig((/* ctx */) => {
         '/api': {
           target: 'http://localhost:3000',
           changeOrigin: true,
+          rewrite: (path: string) =>
+            path.replace(/^\/api\/checkout/, '/checkout'),
         },
       },
     },

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -79,6 +79,7 @@ async function pay() {
     });
     if (!prefRes.ok) throw new Error('Error creando preferencia');
     const { init_point } = await prefRes.json();
+    if (!init_point) throw new Error('init_point vacío');
     window.location.href = init_point;
   } catch (err) {
     $q.notify({ type: 'negative', message: (err as Error).message });


### PR DESCRIPTION
## Summary
- rewrite /api/checkout to /checkout in dev proxy
- handle empty init_point and redirect to MercadoPago in cart page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4d226cad0832598b886aefb226435