### PR TITLE
feat: secure admin API access

### DIFF
--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -88,6 +88,10 @@ export default defineConfig((/* ctx */) => {
           rewrite: (path: string) =>
             path.replace(/^\/api\/checkout/, '/checkout'),
         },
+        '/admin': {
+          target: 'http://localhost:3000',
+          changeOrigin: true,
+        },
       },
     },
 

--- a/frontend/src/pages/AdminOrdersPage.vue
+++ b/frontend/src/pages/AdminOrdersPage.vue
@@ -14,6 +14,7 @@ import { ref } from 'vue';
 import { useQuasar } from 'quasar';
 import { useOrdersStore } from 'src/stores/orders';
 import type { Order } from 'src/types/order';
+import axios from 'axios';
 
 const $q = useQuasar();
 const ordersStore = useOrdersStore();
@@ -30,10 +31,14 @@ async function fetch() {
   try {
     await ordersStore.fetch(filter.value);
   } catch (err) {
-    $q.notify({
-      type: 'negative',
-      message: 'Error cargando pedidos: ' + (err as Error).message,
-    });
+    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+      $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else {
+      $q.notify({
+        type: 'negative',
+        message: 'Error cargando pedidos: ' + (err as Error).message,
+      });
+    }
   }
 }
 void fetch();
@@ -42,10 +47,14 @@ async function updateStatus(row: Order, status: string) {
     await ordersStore.updateStatus(row.id, status);
     $q.notify({ type: 'positive', message: 'Estado actualizado' });
   } catch (err) {
-    $q.notify({
-      type: 'negative',
-      message: 'Error actualizando pedido: ' + (err as Error).message,
-    });
+    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+      $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else {
+      $q.notify({
+        type: 'negative',
+        message: 'Error actualizando pedido: ' + (err as Error).message,
+      });
+    }
   }
 }
 </script>

--- a/frontend/src/pages/AdminProductsPage.vue
+++ b/frontend/src/pages/AdminProductsPage.vue
@@ -32,6 +32,7 @@ import { ref } from 'vue';
 import { useQuasar } from 'quasar';
 import { useProductsStore } from 'src/stores/products';
 import type { Product } from 'src/types/product';
+import axios from 'axios';
 
 const $q = useQuasar();
 const productsStore = useProductsStore();
@@ -40,10 +41,14 @@ async function fetchProducts() {
   try {
     await productsStore.fetch();
   } catch (err) {
-    $q.notify({
-      type: 'negative',
-      message: 'Error cargando productos: ' + (err as Error).message,
-    });
+    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+      $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else {
+      $q.notify({
+        type: 'negative',
+        message: 'Error cargando productos: ' + (err as Error).message,
+      });
+    }
   }
 }
 
@@ -82,10 +87,14 @@ async function save() {
     dialog.value = false;
     await fetchProducts();
   } catch (err) {
-    $q.notify({
-      type: 'negative',
-      message: 'Error guardando producto: ' + (err as Error).message,
-    });
+    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+      $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else {
+      $q.notify({
+        type: 'negative',
+        message: 'Error guardando producto: ' + (err as Error).message,
+      });
+    }
   }
 }
 async function remove(id: number) {
@@ -94,10 +103,14 @@ async function remove(id: number) {
     $q.notify({ type: 'positive', message: 'Producto eliminado' });
     await fetchProducts();
   } catch (err) {
-    $q.notify({
-      type: 'negative',
-      message: 'Error eliminando producto: ' + (err as Error).message,
-    });
+    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+      $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else {
+      $q.notify({
+        type: 'negative',
+        message: 'Error eliminando producto: ' + (err as Error).message,
+      });
+    }
   }
 }
 </script>

--- a/frontend/src/stores/orders.ts
+++ b/frontend/src/stores/orders.ts
@@ -1,16 +1,26 @@
 import { defineStore } from 'pinia';
-import axios from 'axios';
+import { api } from 'src/api/api';
+import { useAuthStore } from './auth';
 import type { Order } from 'src/types/order';
 
 export const useOrdersStore = defineStore('adminOrders', {
   state: () => ({ orders: [] as Order[] }),
   actions: {
     async fetch(status?: string) {
-      const { data } = await axios.get('/api/admin/orders', { params: { status } });
+      const auth = useAuthStore();
+      const { data } = await api.get('/admin/orders', {
+        params: { status },
+        headers: { Authorization: `Bearer ${auth.token}` },
+      });
       this.orders = data;
     },
     async updateStatus(id: number, status: string) {
-      await axios.patch(`/api/admin/orders/${id}/status`, { status });
+      const auth = useAuthStore();
+      await api.patch(
+        `/admin/orders/${id}/status`,
+        { status },
+        { headers: { Authorization: `Bearer ${auth.token}` } }
+      );
       await this.fetch();
     },
   },

--- a/frontend/src/stores/products.ts
+++ b/frontend/src/stores/products.ts
@@ -1,15 +1,20 @@
 import { defineStore } from 'pinia';
 import { api } from 'src/api/api';
 import type { Product } from 'src/types/product';
+import { useAuthStore } from './auth';
 
 export const useProductsStore = defineStore('adminProducts', {
   state: () => ({ products: [] as Product[] }),
   actions: {
     async fetch() {
-      const { data } = await api.get('/api/admin/products');
+      const auth = useAuthStore();
+      const { data } = await api.get('/admin/products', {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      });
       this.products = data;
     },
     async save(product: Partial<Product>, images: File[]) {
+      const auth = useAuthStore();
       const form = new FormData();
       Object.entries(product).forEach(([k, v]) => {
         if (v != null) form.append(k, String(v));
@@ -17,19 +22,31 @@ export const useProductsStore = defineStore('adminProducts', {
       images.forEach((img) => form.append('images', img));
 
       if (product.id) {
-        await api.put(`/api/admin/products/${product.id}`, form);
+        await api.put(`/admin/products/${product.id}`, form, {
+          headers: { Authorization: `Bearer ${auth.token}` },
+        });
       } else {
-        await api.post('/api/admin/products', form);
+        await api.post('/admin/products', form, {
+          headers: { Authorization: `Bearer ${auth.token}` },
+        });
       }
 
       await this.fetch();
     },
     async updateStock(id: number, stock: number) {
-      await api.patch(`/api/admin/products/${id}/stock`, { stock });
+      const auth = useAuthStore();
+      await api.patch(
+        `/admin/products/${id}/stock`,
+        { stock },
+        { headers: { Authorization: `Bearer ${auth.token}` } }
+      );
       await this.fetch();
     },
     async delete(id: number) {
-      await api.delete(`/api/admin/products/${id}`);
+      const auth = useAuthStore();
+      await api.delete(`/admin/products/${id}`, {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      });
       await this.fetch();
     },
   },


### PR DESCRIPTION
## Summary
- fix frontend admin routes to use `/admin` and send JWT in Authorization headers
- proxy `/admin` to backend in Quasar dev server
- show admin access denied notifications on 401/403 responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4de44b9b4832599f8c1df06e65ef4