### PR TITLE
fix(admin): corregir rutas, auth JWT y notificaciones

### DIFF
--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -91,6 +91,7 @@ export default defineConfig((/* ctx */) => {
         '/admin': {
           target: 'http://localhost:3000',
           changeOrigin: true,
+          rewrite: (path: string) => path.replace(/^\/admin/, '/admin'),
         },
       },
     },
@@ -110,7 +111,7 @@ export default defineConfig((/* ctx */) => {
       // directives: [],
 
       // Quasar plugins
-      plugins: [],
+      plugins: ['Notify'],
     },
 
     // animations: 'all', // --- includes all animations

--- a/frontend/src/pages/AdminOrdersPage.vue
+++ b/frontend/src/pages/AdminOrdersPage.vue
@@ -30,6 +30,7 @@ const filter = ref();
 async function fetch() {
   try {
     await ordersStore.fetch(filter.value);
+    $q.notify({ type: 'positive', message: 'Pedidos cargados' });
   } catch (err) {
     if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
       $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });

--- a/frontend/src/pages/AdminProductsPage.vue
+++ b/frontend/src/pages/AdminProductsPage.vue
@@ -40,6 +40,7 @@ const productsStore = useProductsStore();
 async function fetchProducts() {
   try {
     await productsStore.fetch();
+    $q.notify({ type: 'positive', message: 'Productos cargados' });
   } catch (err) {
     if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
       $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });

--- a/frontend/src/stores/orders.ts
+++ b/frontend/src/stores/orders.ts
@@ -9,6 +9,7 @@ export const useOrdersStore = defineStore('adminOrders', {
     async fetch(status?: string) {
       const auth = useAuthStore();
       const { data } = await api.get('/admin/orders', {
+        baseURL: '',
         params: { status },
         headers: { Authorization: `Bearer ${auth.token}` },
       });
@@ -19,7 +20,7 @@ export const useOrdersStore = defineStore('adminOrders', {
       await api.patch(
         `/admin/orders/${id}/status`,
         { status },
-        { headers: { Authorization: `Bearer ${auth.token}` } }
+        { baseURL: '', headers: { Authorization: `Bearer ${auth.token}` } }
       );
       await this.fetch();
     },

--- a/frontend/src/stores/products.ts
+++ b/frontend/src/stores/products.ts
@@ -9,6 +9,7 @@ export const useProductsStore = defineStore('adminProducts', {
     async fetch() {
       const auth = useAuthStore();
       const { data } = await api.get('/admin/products', {
+        baseURL: '',
         headers: { Authorization: `Bearer ${auth.token}` },
       });
       this.products = data;
@@ -23,10 +24,12 @@ export const useProductsStore = defineStore('adminProducts', {
 
       if (product.id) {
         await api.put(`/admin/products/${product.id}`, form, {
+          baseURL: '',
           headers: { Authorization: `Bearer ${auth.token}` },
         });
       } else {
         await api.post('/admin/products', form, {
+          baseURL: '',
           headers: { Authorization: `Bearer ${auth.token}` },
         });
       }
@@ -38,13 +41,14 @@ export const useProductsStore = defineStore('adminProducts', {
       await api.patch(
         `/admin/products/${id}/stock`,
         { stock },
-        { headers: { Authorization: `Bearer ${auth.token}` } }
+        { baseURL: '', headers: { Authorization: `Bearer ${auth.token}` } }
       );
       await this.fetch();
     },
     async delete(id: number) {
       const auth = useAuthStore();
       await api.delete(`/admin/products/${id}`, {
+        baseURL: '',
         headers: { Authorization: `Bearer ${auth.token}` },
       });
       await this.fetch();


### PR DESCRIPTION
## Summary
- envía el token JWT en stores de productos y órdenes y utiliza las rutas /admin
- agrega proxy de /admin y registra Notify en Quasar
- muestra notificaciones de éxito y error en páginas de administración

## Testing
- `npm test`
- `npm test -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b4e2d75d1083258ac2ae840c63edc1