### PR TITLE
fix(admin): alinear rutas, agregar auth header y seed usuario admin

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -18,6 +18,17 @@ async function main() {
     },
   });
 
+  const exampleAdminHash = await bcrypt.hash('admin', 10);
+  await prisma.user.upsert({
+    where: { email: 'admin@example.com' },
+    update: {},
+    create: {
+      email: 'admin@example.com',
+      role: Role.ADMIN,
+      passwordHash: exampleAdminHash,
+    },
+  });
+
   const demoHash = await bcrypt.hash('demo1234', 10);
   await prisma.user.upsert({
     where: { email: 'alice@example.com' },

--- a/frontend/src/stores/orders.ts
+++ b/frontend/src/stores/orders.ts
@@ -2,27 +2,52 @@ import { defineStore } from 'pinia';
 import { api } from 'src/api/api';
 import { useAuthStore } from './auth';
 import type { Order } from 'src/types/order';
+import { useQuasar } from 'quasar';
 
 export const useOrdersStore = defineStore('adminOrders', {
   state: () => ({ orders: [] as Order[] }),
   actions: {
     async fetch(status?: string) {
       const auth = useAuthStore();
-      const { data } = await api.get('/admin/orders', {
-        baseURL: '',
-        params: { status },
-        headers: { Authorization: `Bearer ${auth.token}` },
-      });
-      this.orders = data;
+      const $q = useQuasar();
+      try {
+        const { data } = await api.get('/api/admin/orders', {
+          params: { status },
+          headers: { Authorization: `Bearer ${auth.token}` },
+        });
+        this.orders = data;
+      } catch (err: any) {
+        const statusCode = err.response?.status;
+        $q.notify({
+          type: 'negative',
+          message:
+            statusCode === 401 || statusCode === 403
+              ? 'No autorizado'
+              : err.response?.data?.message || 'Error al cargar órdenes',
+        });
+      }
     },
     async updateStatus(id: number, status: string) {
       const auth = useAuthStore();
-      await api.patch(
-        `/admin/orders/${id}/status`,
-        { status },
-        { baseURL: '', headers: { Authorization: `Bearer ${auth.token}` } }
-      );
-      await this.fetch();
+      const $q = useQuasar();
+      try {
+        await api.patch(
+          `/api/admin/orders/${id}/status`,
+          { status },
+          { headers: { Authorization: `Bearer ${auth.token}` } }
+        );
+        $q.notify({ type: 'positive', message: 'Estado actualizado' });
+        await this.fetch();
+      } catch (err: any) {
+        const statusCode = err.response?.status;
+        $q.notify({
+          type: 'negative',
+          message:
+            statusCode === 401 || statusCode === 403
+              ? 'No autorizado'
+              : err.response?.data?.message || 'Error al actualizar orden',
+        });
+      }
     },
   },
 });

--- a/frontend/src/stores/products.ts
+++ b/frontend/src/stores/products.ts
@@ -2,56 +2,102 @@ import { defineStore } from 'pinia';
 import { api } from 'src/api/api';
 import type { Product } from 'src/types/product';
 import { useAuthStore } from './auth';
+import { useQuasar } from 'quasar';
 
 export const useProductsStore = defineStore('adminProducts', {
   state: () => ({ products: [] as Product[] }),
   actions: {
     async fetch() {
       const auth = useAuthStore();
-      const { data } = await api.get('/admin/products', {
-        baseURL: '',
-        headers: { Authorization: `Bearer ${auth.token}` },
-      });
-      this.products = data;
+      const $q = useQuasar();
+      try {
+        const { data } = await api.get('/api/admin/products', {
+          headers: { Authorization: `Bearer ${auth.token}` },
+        });
+        this.products = data;
+      } catch (err: any) {
+        const status = err.response?.status;
+        $q.notify({
+          type: 'negative',
+          message:
+            status === 401 || status === 403
+              ? 'No autorizado'
+              : err.response?.data?.message || 'Error al cargar productos',
+        });
+      }
     },
     async save(product: Partial<Product>, images: File[]) {
       const auth = useAuthStore();
+      const $q = useQuasar();
       const form = new FormData();
       Object.entries(product).forEach(([k, v]) => {
         if (v != null) form.append(k, String(v));
       });
       images.forEach((img) => form.append('images', img));
-
-      if (product.id) {
-        await api.put(`/admin/products/${product.id}`, form, {
-          baseURL: '',
-          headers: { Authorization: `Bearer ${auth.token}` },
-        });
-      } else {
-        await api.post('/admin/products', form, {
-          baseURL: '',
-          headers: { Authorization: `Bearer ${auth.token}` },
+      try {
+        if (product.id) {
+          await api.put(`/api/admin/products/${product.id}`, form, {
+            headers: { Authorization: `Bearer ${auth.token}` },
+          });
+        } else {
+          await api.post('/api/admin/products', form, {
+            headers: { Authorization: `Bearer ${auth.token}` },
+          });
+        }
+        $q.notify({ type: 'positive', message: 'Producto guardado' });
+        await this.fetch();
+      } catch (err: any) {
+        const status = err.response?.status;
+        $q.notify({
+          type: 'negative',
+          message:
+            status === 401 || status === 403
+              ? 'No autorizado'
+              : err.response?.data?.message || 'Error al guardar producto',
         });
       }
-
-      await this.fetch();
     },
     async updateStock(id: number, stock: number) {
       const auth = useAuthStore();
-      await api.patch(
-        `/admin/products/${id}/stock`,
-        { stock },
-        { baseURL: '', headers: { Authorization: `Bearer ${auth.token}` } }
-      );
-      await this.fetch();
+      const $q = useQuasar();
+      try {
+        await api.patch(
+          `/api/admin/products/${id}/stock`,
+          { stock },
+          { headers: { Authorization: `Bearer ${auth.token}` } }
+        );
+        $q.notify({ type: 'positive', message: 'Stock actualizado' });
+        await this.fetch();
+      } catch (err: any) {
+        const status = err.response?.status;
+        $q.notify({
+          type: 'negative',
+          message:
+            status === 401 || status === 403
+              ? 'No autorizado'
+              : err.response?.data?.message || 'Error al actualizar stock',
+        });
+      }
     },
     async delete(id: number) {
       const auth = useAuthStore();
-      await api.delete(`/admin/products/${id}`, {
-        baseURL: '',
-        headers: { Authorization: `Bearer ${auth.token}` },
-      });
-      await this.fetch();
+      const $q = useQuasar();
+      try {
+        await api.delete(`/api/admin/products/${id}`, {
+          headers: { Authorization: `Bearer ${auth.token}` },
+        });
+        $q.notify({ type: 'positive', message: 'Producto eliminado' });
+        await this.fetch();
+      } catch (err: any) {
+        const status = err.response?.status;
+        $q.notify({
+          type: 'negative',
+          message:
+            status === 401 || status === 403
+              ? 'No autorizado'
+              : err.response?.data?.message || 'Error al eliminar producto',
+        });
+      }
     },
   },
 });


### PR DESCRIPTION
## Summary
- align admin stores with `/api/admin` endpoints and inject auth token with error/success notifications
- seed test admin user `admin@example.com`

## Testing
- `npm test`
- `npm test -w backend` (fails: expected 200 got 400)
- `npm test -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b4e63c9828832585ab2d18051f3b99