### PR TITLE
Fix auth API paths and handle login errors

### DIFF
--- a/frontend/src/components/AuthForm.vue
+++ b/frontend/src/components/AuthForm.vue
@@ -11,29 +11,31 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { useRouter } from 'vue-router';
-import { useAuthStore } from 'src/stores/auth';
 
 interface Props {
   mode: 'login' | 'register';
 }
 
 const props = defineProps<Props>();
+const emit = defineEmits<{
+  (
+    e: 'submit',
+    payload: { email: string; name: string; password: string }
+  ): void;
+}>();
+
 const email = ref('');
 const name = ref('');
 const password = ref('');
-const auth = useAuthStore();
-const router = useRouter();
 
 const buttonLabel = computed(() => (props.mode === 'login' ? 'Login' : 'Register'));
 
-async function onSubmit() {
-  if (props.mode === 'login') {
-    await auth.login(email.value, password.value);
-  } else {
-    await auth.register(email.value, name.value, password.value);
-  }
-  await router.push('/');
+function onSubmit() {
+  emit('submit', {
+    email: email.value,
+    name: name.value,
+    password: password.value,
+  });
 }
 </script>
 

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -1,10 +1,35 @@
 <template>
   <q-page class="flex flex-center">
-    <AuthForm mode="login" />
+    <AuthForm mode="login" @submit="onSubmit" />
   </q-page>
 </template>
 
 <script setup lang="ts">
 import AuthForm from 'components/AuthForm.vue';
+import { useAuthStore } from 'src/stores/auth';
+import { useRouter } from 'vue-router';
+import { useQuasar } from 'quasar';
+
+const auth = useAuthStore();
+const router = useRouter();
+const $q = useQuasar();
+
+async function onSubmit({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}) {
+  try {
+    await auth.login(email, password);
+    await router.push('/');
+  } catch (error) {
+    $q.notify({
+      type: 'negative',
+      message: 'Error al iniciar sesión: ' + (error as Error).message,
+    });
+  }
+}
 </script>
 

--- a/frontend/src/pages/RegisterPage.vue
+++ b/frontend/src/pages/RegisterPage.vue
@@ -1,10 +1,37 @@
 <template>
   <q-page class="flex flex-center">
-    <AuthForm mode="register" />
+    <AuthForm mode="register" @submit="onSubmit" />
   </q-page>
 </template>
 
 <script setup lang="ts">
 import AuthForm from 'components/AuthForm.vue';
+import { useAuthStore } from 'src/stores/auth';
+import { useRouter } from 'vue-router';
+import { useQuasar } from 'quasar';
+
+const auth = useAuthStore();
+const router = useRouter();
+const $q = useQuasar();
+
+async function onSubmit({
+  email,
+  name,
+  password,
+}: {
+  email: string;
+  name: string;
+  password: string;
+}) {
+  try {
+    await auth.register(email, name, password);
+    await router.push('/');
+  } catch (error) {
+    $q.notify({
+      type: 'negative',
+      message: 'Error al registrarse: ' + (error as Error).message,
+    });
+  }
+}
 </script>
 

--- a/frontend/src/stores/__tests__/auth-login.test.ts
+++ b/frontend/src/stores/__tests__/auth-login.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useAuthStore } from '../auth';
+import { useQuasar } from 'quasar';
+import { useRouter } from 'vue-router';
+
+vi.mock('quasar', () => ({ useQuasar: vi.fn() }));
+vi.mock('vue-router', () => ({ useRouter: vi.fn() }));
+
+describe('auth login', () => {
+  let notify: ReturnType<typeof vi.fn>;
+  let push: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    notify = vi.fn();
+    push = vi.fn();
+    (useQuasar as unknown as Mock).mockReturnValue({ notify });
+    (useRouter as unknown as Mock).mockReturnValue({ push });
+  });
+
+  it('stores token on successful login', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ token: 'abc123' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: '1',
+            email: 'test@example.com',
+            role: 'USER',
+            createdAt: '',
+          }),
+      }) as unknown as typeof fetch;
+
+    const store = useAuthStore();
+    await store.login('test@example.com', 'password');
+    expect(store.token).toBe('abc123');
+  });
+
+  it('notifies on login error', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false }) as unknown as typeof fetch;
+
+    const store = useAuthStore();
+
+    const onSubmit = async () => {
+      try {
+        await store.login('bad@example.com', 'bad');
+        await push('/');
+      } catch (error) {
+        notify({
+          type: 'negative',
+          message: 'Error al iniciar sesión: ' + (error as Error).message,
+        });
+      }
+    };
+
+    await onSubmit();
+    expect(notify).toHaveBeenCalledWith({
+      type: 'negative',
+      message: 'Error al iniciar sesión: Login failed',
+    });
+  });
+});

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -13,9 +13,6 @@ interface AuthState {
   user: User | null;
 }
 
-const apiBase =
-  import.meta.env.VITE_API_URL || import.meta.env.VITE_API_BASE_URL || '';
-
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
     token: localStorage.getItem('token'),
@@ -27,7 +24,7 @@ export const useAuthStore = defineStore('auth', {
   },
   actions: {
     async login(email: string, password: string) {
-      const res = await fetch(`${apiBase}/auth/login`, {
+      const res = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
@@ -39,7 +36,7 @@ export const useAuthStore = defineStore('auth', {
       await this.fetchMe();
     },
     async register(email: string, name: string, password: string) {
-      const res = await fetch(`${apiBase}/auth/register`, {
+      const res = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password, name }),
@@ -49,7 +46,7 @@ export const useAuthStore = defineStore('auth', {
     },
     async fetchMe() {
       if (!this.token) return;
-      const res = await fetch(`${apiBase}/auth/me`, {
+      const res = await fetch('/api/auth/me', {
         headers: { Authorization: `Bearer ${this.token}` },
       });
       if (res.ok) {


### PR DESCRIPTION
## Summary
- remove VITE_API_URL usage in auth store and call `/api` endpoints
- handle login/register form submission in pages and show errors with $q.notify
- add store tests for login success and failure

## Testing
- `npm run lint -w frontend`
- `npm test -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b4fa497730832594bdf8a0499e6cf7