### PR TITLE
fix(cart+admin): adaptar estructura de carrito y corregir proxy de rutas admin

### DIFF
--- a/backend/test/admin-auth.integration.test.ts
+++ b/backend/test/admin-auth.integration.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
+import express from 'express';
 import bcrypt from 'bcryptjs';
 import type { PrismaClient } from '@prisma/client';
 
@@ -45,29 +46,32 @@ beforeAll(async () => {
 
 beforeEach(() => {
   const prisma = new FakePrisma() as unknown as PrismaClient;
-  app = createApp(prisma);
+  const base = createApp(prisma);
+  const api = express();
+  api.use('/api', base);
+  app = api;
 });
 
 describe('admin auth', () => {
   it('allows seeded admins to login and access protected routes', async () => {
     const login1 = await request(app)
-      .post('/auth/login')
+      .post('/api/auth/login')
       .send({ email: 'admin@example.com', password: 'admin1234' })
       .expect(200);
     expect(login1.body.token).toBeTruthy();
 
     const login2 = await request(app)
-      .post('/auth/login')
+      .post('/api/auth/login')
       .send({ email: 'admin2@example.com', password: 'admin12345' })
       .expect(200);
     expect(login2.body.token).toBeTruthy();
 
     await request(app)
-      .get('/admin/products')
+      .get('/api/admin/products')
       .set('Authorization', `Bearer ${login1.body.token}`)
       .expect(200);
 
-    await request(app).get('/admin/products').expect(401);
+    await request(app).get('/api/admin/products').expect(401);
   });
 });
 

--- a/frontend/quasar.config.ts
+++ b/frontend/quasar.config.ts
@@ -88,11 +88,6 @@ export default defineConfig((/* ctx */) => {
           rewrite: (path: string) =>
             path.replace(/^\/api\/checkout/, '/checkout'),
         },
-        '/admin': {
-          target: 'http://localhost:3000',
-          changeOrigin: true,
-          rewrite: (path: string) => path.replace(/^\/admin/, '/admin'),
-        },
       },
     },
 

--- a/frontend/src/pages/AdminOrdersPage.vue
+++ b/frontend/src/pages/AdminOrdersPage.vue
@@ -32,8 +32,11 @@ async function fetch() {
     await ordersStore.fetch(filter.value);
     $q.notify({ type: 'positive', message: 'Pedidos cargados' });
   } catch (err) {
-    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+    if (status === 401 || status === 403) {
       $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else if (status === 404) {
+      $q.notify({ type: 'negative', message: 'Recurso no encontrado' });
     } else {
       $q.notify({
         type: 'negative',
@@ -48,8 +51,11 @@ async function updateStatus(row: Order, status: string) {
     await ordersStore.updateStatus(row.id, status);
     $q.notify({ type: 'positive', message: 'Estado actualizado' });
   } catch (err) {
-    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+    if (status === 401 || status === 403) {
       $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else if (status === 404) {
+      $q.notify({ type: 'negative', message: 'Recurso no encontrado' });
     } else {
       $q.notify({
         type: 'negative',

--- a/frontend/src/pages/AdminProductsPage.vue
+++ b/frontend/src/pages/AdminProductsPage.vue
@@ -42,8 +42,11 @@ async function fetchProducts() {
     await productsStore.fetch();
     $q.notify({ type: 'positive', message: 'Productos cargados' });
   } catch (err) {
-    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+    if (status === 401 || status === 403) {
       $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else if (status === 404) {
+      $q.notify({ type: 'negative', message: 'Recurso no encontrado' });
     } else {
       $q.notify({
         type: 'negative',
@@ -88,8 +91,11 @@ async function save() {
     dialog.value = false;
     await fetchProducts();
   } catch (err) {
-    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+    if (status === 401 || status === 403) {
       $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else if (status === 404) {
+      $q.notify({ type: 'negative', message: 'Recurso no encontrado' });
     } else {
       $q.notify({
         type: 'negative',
@@ -104,8 +110,11 @@ async function remove(id: number) {
     $q.notify({ type: 'positive', message: 'Producto eliminado' });
     await fetchProducts();
   } catch (err) {
-    if (axios.isAxiosError(err) && [401, 403].includes(err.response?.status || 0)) {
+    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+    if (status === 401 || status === 403) {
       $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
+    } else if (status === 404) {
+      $q.notify({ type: 'negative', message: 'Recurso no encontrado' });
     } else {
       $q.notify({
         type: 'negative',

--- a/frontend/src/stores/__tests__/cart-transform.test.ts
+++ b/frontend/src/stores/__tests__/cart-transform.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const axiosInstance = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+})) as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+vi.mock('axios', () => ({
+  default: { create: () => axiosInstance },
+  create: () => axiosInstance,
+}));
+
+vi.mock('quasar', () => ({ useQuasar: vi.fn() }));
+
+import { useCartStore } from '../cart';
+import { useAuthStore } from '../auth';
+import { useQuasar } from 'quasar';
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('cart store transform', () => {
+  let notify: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    notify = vi.fn();
+    (useQuasar as unknown as Mock).mockReturnValue({ notify });
+    axiosInstance.get.mockReset();
+    axiosInstance.post.mockReset();
+    // stub localStorage
+    globalThis.localStorage = {
+      getItem: () => null,
+      setItem: () => undefined,
+      removeItem: () => undefined,
+      clear: () => undefined,
+      key: () => null,
+      length: 0,
+    } as Storage;
+  });
+
+  it('maps backend items and calculates subtotal', async () => {
+    axiosInstance.get.mockResolvedValue({
+      data: {
+        items: [
+          { quantity: 2, product: { id: 1, name: 'Taza', priceCents: 1299 } },
+        ],
+      },
+    });
+
+    const auth = useAuthStore();
+    const store = useCartStore();
+
+    auth.token = 'token';
+    await flushPromises();
+    await flushPromises();
+
+    expect(store.cart[0]).toMatchObject({
+      productId: 1,
+      name: 'Taza',
+      priceCents: 1299,
+      qty: 2,
+    });
+    expect(store.subtotal).toBe(2598);
+  });
+});
+

--- a/frontend/src/stores/cart.ts
+++ b/frontend/src/stores/cart.ts
@@ -4,12 +4,14 @@ import axios from 'axios';
 import { useAuthStore } from './auth';
 import type { CartItem } from 'src/types/cart';
 import type { Product } from 'src/types/product';
+import { useQuasar } from 'quasar';
 
 const STORAGE_KEY = 'cart';
 const api = axios.create({ baseURL: import.meta.env.VITE_API_URL || '' });
 
 export const useCartStore = defineStore('cart', () => {
   const auth = useAuthStore();
+  const $q = useQuasar();
   const cart = ref<CartItem[]>([]);
 
   // Subtotal y total siempre calculados con priceCents
@@ -34,14 +36,33 @@ export const useCartStore = defineStore('cart', () => {
 
   // Cargar carrito remoto
   async function fetchRemote() {
-    const { data } = await api.get('/api/cart', {
-      headers: { Authorization: `Bearer ${auth.token}` },
-    });
+    try {
+      const { data } = await api.get('/api/cart', {
+        headers: { Authorization: `Bearer ${auth.token}` },
+      });
 
-    const items = (data.items ?? []) as Array<Partial<CartItem>>;
-    cart.value = items.map(
-      (item) => ({ ...item, priceCents: item.priceCents ?? 0 } as CartItem),
-    );
+      const items = data.items ?? [];
+      const mapped: CartItem[] = [];
+      for (const item of items) {
+        try {
+          mapped.push({
+            productId: item.product.id,
+            name: item.product.name,
+            priceCents: item.product.priceCents,
+            currency: item.product.currency ?? 'USD',
+            qty: item.quantity,
+            stock: item.product.stock ?? 0,
+            image_url: item.product.image_url ?? '',
+          });
+        } catch {
+          $q.notify({ type: 'negative', message: 'Item de carrito inválido' });
+        }
+      }
+      cart.value = mapped;
+    } catch {
+      $q.notify({ type: 'negative', message: 'Error cargando carrito' });
+      cart.value = [];
+    }
   }
 
   // Fusionar carrito local al remoto
@@ -65,12 +86,16 @@ export const useCartStore = defineStore('cart', () => {
   // Agregar producto al carrito
   async function add(product: Product, qty = 1) {
     if (auth.isAuthenticated) {
-      await api.post(
-        '/api/cart/add',
-        { productId: product.id, quantity: qty },
-        { headers: { Authorization: `Bearer ${auth.token}` } },
-      );
-      await fetchRemote();
+      try {
+        await api.post(
+          '/api/cart/add',
+          { productId: product.id, quantity: qty },
+          { headers: { Authorization: `Bearer ${auth.token}` } },
+        );
+        await fetchRemote();
+      } catch {
+        $q.notify({ type: 'negative', message: 'Error agregando al carrito' });
+      }
     } else {
       const existing = cart.value.find((l) => l.productId === product.id);
       const target = existing ? existing.qty + qty : qty;
@@ -97,12 +122,16 @@ export const useCartStore = defineStore('cart', () => {
   // Actualizar cantidad
   async function updateQty(productId: number, qty: number) {
     if (auth.isAuthenticated) {
-      await api.post(
-        '/api/cart/update',
-        { productId, quantity: qty },
-        { headers: { Authorization: `Bearer ${auth.token}` } },
-      );
-      await fetchRemote();
+      try {
+        await api.post(
+          '/api/cart/update',
+          { productId, quantity: qty },
+          { headers: { Authorization: `Bearer ${auth.token}` } },
+        );
+        await fetchRemote();
+      } catch {
+        $q.notify({ type: 'negative', message: 'Error actualizando carrito' });
+      }
     } else {
       const line = cart.value.find((l) => l.productId === productId);
       if (!line) return;
@@ -114,12 +143,16 @@ export const useCartStore = defineStore('cart', () => {
   // Remover producto
   async function remove(productId: number) {
     if (auth.isAuthenticated) {
-      await api.post(
-        '/api/cart/remove',
-        { productId },
-        { headers: { Authorization: `Bearer ${auth.token}` } },
-      );
-      await fetchRemote();
+      try {
+        await api.post(
+          '/api/cart/remove',
+          { productId },
+          { headers: { Authorization: `Bearer ${auth.token}` } },
+        );
+        await fetchRemote();
+      } catch {
+        $q.notify({ type: 'negative', message: 'Error removiendo del carrito' });
+      }
     } else {
       cart.value = cart.value.filter((l) => l.productId !== productId);
       persistLocal();


### PR DESCRIPTION
## Summary
- map new backend cart item structure to frontend CartItem with error notifications
- proxy only `/api/**` to backend so admin SPA routes stay client-side
- improve admin pages with clearer API error handling and add tests for cart mapping and admin auth

## Testing
- `npm run lint -w frontend`
- `npm test -w frontend`
- `npm test -w backend`

------
https://chatgpt.com/codex/tasks/task_e_68b4fd6c8680832597c6816c0fa6597f