### PR TITLE
Use Notify in admin stores and handle form data

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -41,6 +41,9 @@ export function createAdminRouter(prisma: PrismaClient) {
     requireRole('ADMIN', 'MODERATOR'),
     upload.array('images'),
     async (req, res) => {
+      if (!req.is('multipart/form-data')) {
+        return res.status(415).json({ message: 'Content-Type must be multipart/form-data' });
+      }
       const { name, description, priceCents, category, status, stock } = req.body;
       if (Number(priceCents) < 0 || Number(stock) < 0) {
         return res.status(400).json({ message: 'Invalid price or stock' });
@@ -75,6 +78,9 @@ export function createAdminRouter(prisma: PrismaClient) {
     requireRole('ADMIN', 'MODERATOR'),
     upload.array('images'),
     async (req, res) => {
+      if (!req.is('multipart/form-data')) {
+        return res.status(415).json({ message: 'Content-Type must be multipart/form-data' });
+      }
       const { id } = req.params;
       const { name, description, priceCents, category, status, stock } = req.body;
       if (Number(priceCents) < 0 || Number(stock) < 0) {

--- a/backend/test/admin-products.integration.test.ts
+++ b/backend/test/admin-products.integration.test.ts
@@ -1,0 +1,104 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import bcrypt from 'bcryptjs';
+import type { PrismaClient } from '@prisma/client';
+
+vi.mock('../src/utils/s3.js', () => ({ uploadImage: vi.fn().mockResolvedValue('url') }));
+vi.mock('../src/utils/gcs.js', () => ({ uploadImage: vi.fn().mockResolvedValue('url') }));
+
+process.env.JWT_SECRET = 'testsecret';
+process.env.JWT_EXPIRES_IN = '7d';
+
+let createApp: typeof import('../src/app.js').createApp;
+
+const adminHash = bcrypt.hashSync('admin1234', 1);
+
+class FakePrisma {
+  products: any[] = [];
+
+  user = {
+    findUnique: async ({ where: { email, id } }: any) => {
+      if (email) return { id: '1', email, passwordHash: adminHash, role: 'ADMIN' };
+      if (id) return { id, email: 'admin@example.com', passwordHash: adminHash, role: 'ADMIN' };
+      return null;
+    },
+  };
+
+  product = {
+    create: async ({ data }: any) => {
+      const prod = { id: this.products.length + 1, ...data };
+      this.products.push(prod);
+      return prod;
+    },
+    update: async () => ({}),
+  };
+
+  productImage = {
+    createMany: async () => ({}),
+  };
+}
+
+let app: express.Express;
+
+beforeAll(async () => {
+  ({ createApp } = await import('../src/app.js'));
+});
+
+beforeEach(() => {
+  const prisma = new FakePrisma() as unknown as PrismaClient;
+  const base = createApp(prisma);
+  const api = express();
+  api.use('/api', base);
+  app = api;
+});
+
+describe('admin products upload', () => {
+  it('rejects JSON payload', async () => {
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@example.com', password: 'admin1234' })
+      .expect(200);
+    const token = login.body.token;
+    const res = await request(app)
+      .post('/api/admin/products')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Test', priceCents: '100', stock: '1', category: 'cat', status: 'ACTIVE' });
+    expect([400, 415]).toContain(res.status);
+  });
+
+  it('accepts form-data without images', async () => {
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@example.com', password: 'admin1234' })
+      .expect(200);
+    const token = login.body.token;
+    await request(app)
+      .post('/api/admin/products')
+      .set('Authorization', `Bearer ${token}`)
+      .field('name', 'Test')
+      .field('priceCents', '100')
+      .field('stock', '1')
+      .field('category', 'cat')
+      .field('status', 'ACTIVE')
+      .expect(201);
+  });
+
+  it('accepts form-data with images', async () => {
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@example.com', password: 'admin1234' })
+      .expect(200);
+    const token = login.body.token;
+    await request(app)
+      .post('/api/admin/products')
+      .set('Authorization', `Bearer ${token}`)
+      .field('name', 'Test')
+      .field('priceCents', '100')
+      .field('stock', '1')
+      .field('category', 'cat')
+      .field('status', 'ACTIVE')
+      .attach('images', Buffer.from('hello'), 'test.png')
+      .expect(201);
+  });
+});

--- a/frontend/src/stores/__tests__/error-notify.test.ts
+++ b/frontend/src/stores/__tests__/error-notify.test.ts
@@ -14,30 +14,27 @@ vi.mock('src/api/api', () => ({
 }));
 
 vi.mock('quasar', () => ({
-  useQuasar: vi.fn(),
+  Notify: { create: vi.fn() },
 }));
 
 import { useProductsStore } from '../products';
 import { useOrdersStore } from '../orders';
 import { api } from 'src/api/api';
-import { useQuasar } from 'quasar';
+import { Notify } from 'quasar';
 
 describe('stores error handling', () => {
-  let notify: ReturnType<typeof vi.fn>;
-
   beforeEach(() => {
     setActivePinia(createPinia());
-    notify = vi.fn();
-    (useQuasar as unknown as Mock).mockReturnValue({ notify });
+    (Notify.create as unknown as Mock).mockReset();
   });
 
   it('notifies unauthorized on 401', async () => {
     (api.get as unknown as Mock).mockRejectedValueOnce({ response: { status: 401 } });
     const store = useProductsStore();
     await store.fetch();
-    expect(notify).toHaveBeenCalledWith({
+    expect(Notify.create).toHaveBeenCalledWith({
       type: 'negative',
-      message: 'No autorizado: inicia sesión como admin',
+      message: 'No autorizado, inicia sesión como admin',
     });
   });
 
@@ -45,9 +42,9 @@ describe('stores error handling', () => {
     (api.get as unknown as Mock).mockRejectedValueOnce({ response: { status: 500 } });
     const store = useOrdersStore();
     await store.fetch();
-    expect(notify).toHaveBeenCalledWith({
+    expect(Notify.create).toHaveBeenCalledWith({
       type: 'negative',
-      message: 'Error 500',
+      message: 'Error inesperado, inténtalo de nuevo',
     });
   });
 

--- a/frontend/src/stores/__tests__/products-formdata.test.ts
+++ b/frontend/src/stores/__tests__/products-formdata.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+vi.mock('src/api/api', () => ({
+  api: {
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+vi.mock('quasar', () => ({
+  Notify: { create: vi.fn() },
+}));
+
+import { useProductsStore } from '../products';
+import { api } from 'src/api/api';
+import { Notify } from 'quasar';
+
+describe('products store formdata', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    (api.post as unknown as Mock).mockReset();
+    (api.put as unknown as Mock).mockReset();
+    (Notify.create as unknown as Mock).mockReset();
+  });
+
+  it('sends formdata and notifies success', async () => {
+    (api.post as unknown as Mock).mockResolvedValueOnce({});
+    const store = useProductsStore();
+    const file = new File(['hello'], 'img.png', { type: 'image/png' });
+    await store.save(
+      {
+        name: 'Test',
+        priceCents: 100,
+        stock: 5,
+        category: 'cat',
+        status: 'ACTIVE',
+      },
+      [file],
+    );
+    const body = (api.post as unknown as Mock).mock.calls[0][1];
+    expect(body).toBeInstanceOf(FormData);
+    expect(body.get('name')).toBe('Test');
+    expect(body.get('priceCents')).toBe('100');
+    expect(body.getAll('images')).toHaveLength(1);
+    expect(Notify.create).toHaveBeenCalledWith({
+      type: 'positive',
+      message: 'Producto guardado',
+    });
+  });
+
+  it('notifies error on failure', async () => {
+    (api.post as unknown as Mock).mockRejectedValueOnce({ response: { status: 500 } });
+    const store = useProductsStore();
+    await store.save(
+      {
+        name: 'Bad',
+        priceCents: 100,
+        stock: 5,
+        category: 'cat',
+        status: 'ACTIVE',
+      },
+      [],
+    );
+    expect(Notify.create).toHaveBeenCalledWith({
+      type: 'negative',
+      message: 'Error inesperado, inténtalo de nuevo',
+    });
+  });
+});

--- a/frontend/src/stores/orders.ts
+++ b/frontend/src/stores/orders.ts
@@ -2,14 +2,13 @@ import { defineStore } from 'pinia';
 import { api } from 'src/api/api';
 import { useAuthStore } from './auth';
 import type { Order } from 'src/types/order';
-import { useQuasar } from 'quasar';
+import { Notify } from 'quasar';
 
 export const useOrdersStore = defineStore('adminOrders', {
   state: () => ({ orders: [] as Order[] }),
   actions: {
     async fetch(status?: string) {
       const auth = useAuthStore();
-      const $q = useQuasar();
       try {
         const { data } = await api.get('/api/admin/orders', {
           params: { status },
@@ -19,39 +18,34 @@ export const useOrdersStore = defineStore('adminOrders', {
       } catch (err: unknown) {
         const e = err as { response?: { status?: number } };
         const status = e.response?.status;
-        $q.notify({
+        Notify.create({
           type: 'negative',
           message:
-            status === 401
-              ? 'No autorizado: inicia sesión como admin'
-              : status
-              ? `Error ${status}`
-              : 'Error inesperado',
+            status === 401 || status === 403
+              ? 'No autorizado, inicia sesión como admin'
+              : 'Error inesperado, inténtalo de nuevo',
         });
       }
     },
     async updateStatus(id: number, status: string) {
       const auth = useAuthStore();
-      const $q = useQuasar();
       try {
         await api.patch(
           `/api/admin/orders/${id}/status`,
           { status },
           { headers: { Authorization: `Bearer ${auth.token}` } }
         );
-        $q.notify({ type: 'positive', message: 'Estado actualizado' });
+        Notify.create({ type: 'positive', message: 'Estado actualizado' });
         await this.fetch();
       } catch (err: unknown) {
         const e = err as { response?: { status?: number } };
         const status = e.response?.status;
-        $q.notify({
+        Notify.create({
           type: 'negative',
           message:
-            status === 401
-              ? 'No autorizado: inicia sesión como admin'
-              : status
-              ? `Error ${status}`
-              : 'Error inesperado',
+            status === 401 || status === 403
+              ? 'No autorizado, inicia sesión como admin'
+              : 'Error inesperado, inténtalo de nuevo',
         });
       }
     },

--- a/frontend/src/stores/products.ts
+++ b/frontend/src/stores/products.ts
@@ -2,14 +2,13 @@ import { defineStore } from 'pinia';
 import { api } from 'src/api/api';
 import type { Product } from 'src/types/product';
 import { useAuthStore } from './auth';
-import { useQuasar } from 'quasar';
+import { Notify } from 'quasar';
 
 export const useProductsStore = defineStore('adminProducts', {
   state: () => ({ products: [] as Product[] }),
   actions: {
     async fetch() {
       const auth = useAuthStore();
-      const $q = useQuasar();
       try {
         const { data } = await api.get('/api/admin/products', {
           headers: { Authorization: `Bearer ${auth.token}` },
@@ -18,28 +17,29 @@ export const useProductsStore = defineStore('adminProducts', {
       } catch (err: unknown) {
         const e = err as { response?: { status?: number } };
         const status = e.response?.status;
-        $q.notify({
+        Notify.create({
           type: 'negative',
           message:
-            status === 401
-              ? 'No autorizado: inicia sesión como admin'
-              : status
-              ? `Error ${status}`
-              : 'Error inesperado',
+            status === 401 || status === 403
+              ? 'No autorizado, inicia sesión como admin'
+              : 'Error inesperado, inténtalo de nuevo',
         });
       }
     },
     async save(product: Partial<Product>, images: File[]) {
       const auth = useAuthStore();
-      const $q = useQuasar();
       const form = new FormData();
-      Object.entries(product).forEach(([k, v]) => {
-        if (v != null) form.append(k, String(v));
-      });
+      const { id, name, priceCents, stock, category, status, description } = product;
+      if (name != null) form.append('name', String(name));
+      if (description != null) form.append('description', String(description));
+      if (priceCents != null) form.append('priceCents', String(priceCents));
+      if (stock != null) form.append('stock', String(stock));
+      if (category != null) form.append('category', String(category));
+      if (status != null) form.append('status', String(status));
       images.forEach((img) => form.append('images', img));
       try {
-        if (product.id) {
-          await api.put(`/api/admin/products/${product.id}`, form, {
+        if (id) {
+          await api.put(`/api/admin/products/${id}`, form, {
             headers: { Authorization: `Bearer ${auth.token}` },
           });
         } else {
@@ -47,67 +47,59 @@ export const useProductsStore = defineStore('adminProducts', {
             headers: { Authorization: `Bearer ${auth.token}` },
           });
         }
-        $q.notify({ type: 'positive', message: 'Producto guardado' });
+        Notify.create({ type: 'positive', message: 'Producto guardado' });
         await this.fetch();
       } catch (err: unknown) {
         const e = err as { response?: { status?: number } };
         const status = e.response?.status;
-        $q.notify({
+        Notify.create({
           type: 'negative',
           message:
-            status === 401
-              ? 'No autorizado: inicia sesión como admin'
-              : status
-              ? `Error ${status}`
-              : 'Error inesperado',
+            status === 401 || status === 403
+              ? 'No autorizado, inicia sesión como admin'
+              : 'Error inesperado, inténtalo de nuevo',
         });
       }
     },
     async updateStock(id: number, stock: number) {
       const auth = useAuthStore();
-      const $q = useQuasar();
       try {
         await api.patch(
           `/api/admin/products/${id}/stock`,
           { stock },
           { headers: { Authorization: `Bearer ${auth.token}` } }
         );
-        $q.notify({ type: 'positive', message: 'Stock actualizado' });
+        Notify.create({ type: 'positive', message: 'Stock actualizado' });
         await this.fetch();
       } catch (err: unknown) {
         const e = err as { response?: { status?: number } };
         const status = e.response?.status;
-        $q.notify({
+        Notify.create({
           type: 'negative',
           message:
-            status === 401
-              ? 'No autorizado: inicia sesión como admin'
-              : status
-              ? `Error ${status}`
-              : 'Error inesperado',
+            status === 401 || status === 403
+              ? 'No autorizado, inicia sesión como admin'
+              : 'Error inesperado, inténtalo de nuevo',
         });
       }
     },
     async delete(id: number) {
       const auth = useAuthStore();
-      const $q = useQuasar();
       try {
         await api.delete(`/api/admin/products/${id}`, {
           headers: { Authorization: `Bearer ${auth.token}` },
         });
-        $q.notify({ type: 'positive', message: 'Producto eliminado' });
+        Notify.create({ type: 'positive', message: 'Producto eliminado' });
         await this.fetch();
       } catch (err: unknown) {
         const e = err as { response?: { status?: number } };
         const status = e.response?.status;
-        $q.notify({
+        Notify.create({
           type: 'negative',
           message:
-            status === 401
-              ? 'No autorizado: inicia sesión como admin'
-              : status
-              ? `Error ${status}`
-              : 'Error inesperado',
+            status === 401 || status === 403
+              ? 'No autorizado, inicia sesión como admin'
+              : 'Error inesperado, inténtalo de nuevo',
         });
       }
     },


### PR DESCRIPTION
## Summary
- replace `$q.notify` with `Notify.create` in admin stores
- send product data as `FormData` and use `Notify` for success/error
- validate `multipart/form-data` on admin product endpoints
- add integration tests for product uploads and store notifications

## Testing
- `npm run lint -w frontend`
- `npm run lint -w backend` *(fails: ESLint couldn't find config)*
- `npm test -w frontend`
- `npm test -w backend`


------
https://chatgpt.com/codex/tasks/task_e_68b502bc7ec0832584f08674f801d50a