### PR TITLE
Add category/status to products and extend admin auth tests

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -13,7 +13,10 @@ export const registerSchema = z.object({
   password: z.string().min(8),
   name: z.string().min(1).optional(), // 👈 ahora acepta name opcional
 });
-export const loginSchema = registerSchema.omit({ name: true });
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
 
 const JWT_SECRET = process.env.JWT_SECRET ?? '';
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';

--- a/backend/test/admin-auth.integration.test.ts
+++ b/backend/test/admin-auth.integration.test.ts
@@ -16,7 +16,7 @@ process.env.JWT_EXPIRES_IN = '7d';
 
 let createApp: typeof import('../src/app.js').createApp;
 
-const admin1Hash = bcrypt.hashSync('admin1234', 1);
+const admin1Hash = bcrypt.hashSync('admin', 1);
 const admin2Hash = bcrypt.hashSync('admin12345', 1);
 
 class FakePrisma {
@@ -34,7 +34,19 @@ class FakePrisma {
   };
 
   product = {
-    findMany: async () => [],
+    findMany: async () => [
+      {
+        id: 1,
+        name: 'Prod',
+        slug: 'prod',
+        description: 'desc',
+        priceCents: 100,
+        category: 'cat',
+        status: 'ACTIVE',
+        stock: 1,
+        images: [],
+      },
+    ],
   };
 }
 
@@ -56,7 +68,7 @@ describe('admin auth', () => {
   it('allows seeded admins to login and access protected routes', async () => {
     const login1 = await request(app)
       .post('/api/auth/login')
-      .send({ email: 'admin@example.com', password: 'admin1234' })
+      .send({ email: 'admin@example.com', password: 'admin' })
       .expect(200);
     expect(login1.body.token).toBeTruthy();
 
@@ -66,10 +78,11 @@ describe('admin auth', () => {
       .expect(200);
     expect(login2.body.token).toBeTruthy();
 
-    await request(app)
+    const products = await request(app)
       .get('/api/admin/products')
       .set('Authorization', `Bearer ${login1.body.token}`)
       .expect(200);
+    expect(products.body).toHaveLength(1);
 
     await request(app).get('/api/admin/products').expect(401);
   });

--- a/frontend/src/stores/__tests__/cart-transform.test.ts
+++ b/frontend/src/stores/__tests__/cart-transform.test.ts
@@ -13,21 +13,18 @@ vi.mock('axios', () => ({
   create: () => axiosInstance,
 }));
 
-vi.mock('quasar', () => ({ useQuasar: vi.fn() }));
+vi.mock('quasar', () => ({ Notify: { create: vi.fn() } }));
 
 import { useCartStore } from '../cart';
 import { useAuthStore } from '../auth';
-import { useQuasar } from 'quasar';
+import { Notify } from 'quasar';
 
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('cart store transform', () => {
-  let notify: ReturnType<typeof vi.fn>;
-
   beforeEach(() => {
     setActivePinia(createPinia());
-    notify = vi.fn();
-    (useQuasar as unknown as Mock).mockReturnValue({ notify });
+    (Notify.create as unknown as Mock).mockReset();
     axiosInstance.get.mockReset();
     axiosInstance.post.mockReset();
     // stub localStorage

--- a/frontend/src/stores/cart.ts
+++ b/frontend/src/stores/cart.ts
@@ -4,14 +4,13 @@ import axios from 'axios';
 import { useAuthStore } from './auth';
 import type { CartItem } from 'src/types/cart';
 import type { Product } from 'src/types/product';
-import { useQuasar } from 'quasar';
+import { Notify } from 'quasar';
 
 const STORAGE_KEY = 'cart';
 const api = axios.create({ baseURL: import.meta.env.VITE_API_URL || '' });
 
 export const useCartStore = defineStore('cart', () => {
   const auth = useAuthStore();
-  const $q = useQuasar();
   const cart = ref<CartItem[]>([]);
 
   // Subtotal y total siempre calculados con priceCents
@@ -55,12 +54,12 @@ export const useCartStore = defineStore('cart', () => {
             image_url: item.product.image_url ?? '',
           });
         } catch {
-          $q.notify({ type: 'negative', message: 'Item de carrito inválido' });
+          Notify.create({ type: 'negative', message: 'Item de carrito inválido' });
         }
       }
       cart.value = mapped;
     } catch {
-      $q.notify({ type: 'negative', message: 'Error cargando carrito' });
+      Notify.create({ type: 'negative', message: 'Error cargando carrito' });
       cart.value = [];
     }
   }
@@ -94,7 +93,7 @@ export const useCartStore = defineStore('cart', () => {
         );
         await fetchRemote();
       } catch {
-        $q.notify({ type: 'negative', message: 'Error agregando al carrito' });
+        Notify.create({ type: 'negative', message: 'Error agregando al carrito' });
       }
     } else {
       const existing = cart.value.find((l) => l.productId === product.id);
@@ -130,7 +129,7 @@ export const useCartStore = defineStore('cart', () => {
         );
         await fetchRemote();
       } catch {
-        $q.notify({ type: 'negative', message: 'Error actualizando carrito' });
+        Notify.create({ type: 'negative', message: 'Error actualizando carrito' });
       }
     } else {
       const line = cart.value.find((l) => l.productId === productId);
@@ -151,7 +150,7 @@ export const useCartStore = defineStore('cart', () => {
         );
         await fetchRemote();
       } catch {
-        $q.notify({ type: 'negative', message: 'Error removiendo del carrito' });
+        Notify.create({ type: 'negative', message: 'Error removiendo del carrito' });
       }
     } else {
       cart.value = cart.value.filter((l) => l.productId !== productId);

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -6,5 +6,7 @@ export interface Product {
   priceCents: number;
   currency: string;
   stock: number;
+  category: string;
+  status: 'ACTIVE' | 'INACTIVE';
   image_url?: string;
 }


### PR DESCRIPTION
## Summary
- include `category` and `status` fields in frontend product type
- swap `$q.notify` for `Notify.create` in cart store and tests
- add integration test for seeded admin login and product listing
- relax backend login schema to accept seeded admin password length

## Testing
- `npm run lint` (frontend)
- `npm test` (frontend)
- `npm test` (backend)
- `npm run lint` (backend) *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b50617cccc8325a28e63fa5fe84c72