### PR TITLE
Handle product defaults and front-end validation

### DIFF
--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -44,29 +44,91 @@ export function createAdminRouter(prisma: PrismaClient) {
       if (!req.is('multipart/form-data')) {
         return res.status(415).json({ message: 'Content-Type must be multipart/form-data' });
       }
-      const { name, slug: bodySlug, description, priceCents, category, status, stock } = req.body;
-      if (!name || !description || priceCents === undefined) {
-        return res.status(400).json({ message: 'Missing required fields' });
+
+      const {
+        name,
+        slug: bodySlug,
+        description,
+        price,
+        priceCents,
+        category,
+        status,
+        stock,
+      } = req.body;
+
+      const nameVal = name && String(name).trim() !== '' ? String(name).trim() : 'Producto sin nombre';
+      const descriptionVal =
+        description && String(description).trim() !== ''
+          ? String(description).trim()
+          : 'Sin descripción';
+
+      // price can come as price or priceCents
+      let priceCentsVal = 0;
+      if (price != null && String(price).trim() !== '') {
+        priceCentsVal = Math.round(Number(price) * 100);
+      } else if (priceCents != null && String(priceCents).trim() !== '') {
+        priceCentsVal = Number(priceCents);
       }
-      const slug = bodySlug && bodySlug.trim() !== ''
-        ? bodySlug
-        : name.toLowerCase().trim().replace(/\s+/g, '-');
-      const price = Number(priceCents);
-      const stockNum = stock !== undefined ? Number(stock) : 0;
-      if (isNaN(price) || isNaN(stockNum) || price < 0 || stockNum < 0) {
-        return res.status(400).json({ message: 'Invalid price or stock' });
+      if (isNaN(priceCentsVal) || priceCentsVal < 0) {
+        priceCentsVal = 0;
       }
-      const product = await prisma.product.create({
-        data: {
-          name,
-          slug,
-          description,
-          priceCents: price,
-          category,
-          status,
-          stock: stockNum,
-        },
-      });
+
+      let stockNum = Number(stock);
+      if (isNaN(stockNum) || stockNum < 0) {
+        stockNum = 0;
+      }
+
+      const slugBase =
+        bodySlug && bodySlug.trim() !== ''
+          ? bodySlug.trim()
+          : nameVal
+              .toLowerCase()
+              .trim()
+              .normalize('NFD')
+              .replace(/[\u0300-\u036f]/g, '')
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '');
+
+      let slug = slugBase;
+      let suffix = 1;
+      const hasFindUnique = typeof (prisma.product as any).findUnique === 'function';
+      while (hasFindUnique && (await prisma.product.findUnique({ where: { slug } }))) {
+        slug = `${slugBase}-${suffix++}`;
+      }
+
+      let product;
+      try {
+        product = await prisma.product.create({
+          data: {
+            name: nameVal,
+            slug,
+            description: descriptionVal,
+            priceCents: priceCentsVal,
+            category,
+            status,
+            stock: stockNum,
+          },
+        });
+      } catch (e: any) {
+        // Handle unique constraint just in case of race condition
+        if (e.code === 'P2002' && e.meta?.target?.includes('slug')) {
+          slug = `${slugBase}-${suffix++}`;
+          product = await prisma.product.create({
+            data: {
+              name: nameVal,
+              slug,
+              description: descriptionVal,
+              priceCents: priceCentsVal,
+              category,
+              status,
+              stock: stockNum,
+            },
+          });
+        } else {
+          return res.status(500).json({ message: 'Error creating product' });
+        }
+      }
+
       if (req.files) {
         const files = req.files as Express.Multer.File[];
         const uploaded = await Promise.all(
@@ -77,6 +139,7 @@ export function createAdminRouter(prisma: PrismaClient) {
           data: { images: { createMany: { data: uploaded } } },
         });
       }
+
       res.status(201).json(product);
     }
   );

--- a/frontend/src/pages/AdminProductsPage.vue
+++ b/frontend/src/pages/AdminProductsPage.vue
@@ -10,18 +10,34 @@
 
     <q-dialog v-model="dialog">
       <q-card style="min-width:400px">
-        <q-card-section>
-          <q-input v-model="form.name" label="Nombre" />
-          <q-input v-model.number="form.priceCents" label="Precio (cents)" />
-          <q-input v-model.number="form.stock" label="Stock" />
-          <q-input v-model="form.category" label="Categoría" />
-          <q-select v-model="form.status" :options="statusOptions" label="Estado" />
-          <input type="file" multiple @change="onFiles" />
-        </q-card-section>
-        <q-card-actions align="right">
-          <q-btn flat label="Cancelar" v-close-popup />
-          <q-btn flat label="Guardar" color="primary" @click="save" />
-        </q-card-actions>
+        <q-form ref="formRef" @submit.prevent="save">
+          <q-card-section>
+            <q-input
+              v-model="form.name"
+              label="Nombre"
+              :rules="[val => !!val || 'Nombre requerido']"
+            />
+            <q-input
+              v-model="form.description"
+              label="Descripción"
+              :rules="[val => !!val || 'Descripción requerida']"
+            />
+            <q-input
+              v-model.number="form.price"
+              label="Precio"
+              type="number"
+              :rules="[val => val !== null && val !== '' || 'Precio requerido']"
+            />
+            <q-input v-model.number="form.stock" label="Stock" type="number" />
+            <q-input v-model="form.category" label="Categoría" />
+            <q-select v-model="form.status" :options="statusOptions" label="Estado" />
+            <input type="file" multiple @change="onFiles" />
+          </q-card-section>
+          <q-card-actions align="right">
+            <q-btn flat label="Cancelar" v-close-popup />
+            <q-btn flat label="Guardar" color="primary" type="submit" />
+          </q-card-actions>
+        </q-form>
       </q-card>
     </q-dialog>
   </q-page>
@@ -61,6 +77,7 @@ void fetchProducts();
 type AdminProduct = Partial<Product> & {
   category?: string;
   status?: 'ACTIVE' | 'INACTIVE';
+  price?: number;
 };
 
 const columns = [
@@ -74,34 +91,29 @@ const columns = [
 const dialog = ref(false);
 const form = ref<AdminProduct>({});
 const files = ref<File[]>([]);
+const formRef = ref();
 const statusOptions = ['DRAFT','ACTIVE','INACTIVE'];
 
 function openDialog(product?: AdminProduct) {
   form.value = product ? { ...product } : {};
   files.value = [];
+  formRef.value?.resetValidation();
   dialog.value = true;
 }
 function onFiles(e: Event) {
   files.value = Array.from((e.target as HTMLInputElement).files || []);
 }
 async function save() {
+  const valid = await formRef.value.validate();
+  if (!valid) return;
   try {
     await productsStore.save(form.value, files.value);
-    $q.notify({ type: 'positive', message: 'Producto guardado' });
     dialog.value = false;
-    await fetchProducts();
   } catch (err) {
-    const status = axios.isAxiosError(err) ? err.response?.status : undefined;
-    if (status === 401 || status === 403) {
-      $q.notify({ type: 'negative', message: 'Acceso denegado: se requiere rol ADMIN' });
-    } else if (status === 404) {
-      $q.notify({ type: 'negative', message: 'Recurso no encontrado' });
-    } else {
-      $q.notify({
-        type: 'negative',
-        message: 'Error guardando producto: ' + (err as Error).message,
-      });
-    }
+    const message = axios.isAxiosError(err)
+      ? err.response?.data?.message || err.message
+      : (err as Error).message;
+    $q.notify({ type: 'negative', message });
   }
 }
 async function remove(id: number) {

--- a/frontend/src/stores/__tests__/products-formdata.test.ts
+++ b/frontend/src/stores/__tests__/products-formdata.test.ts
@@ -5,6 +5,7 @@ vi.mock('src/api/api', () => ({
   api: {
     post: vi.fn(),
     put: vi.fn(),
+    get: vi.fn(),
   },
 }));
 
@@ -21,17 +22,20 @@ describe('products store formdata', () => {
     setActivePinia(createPinia());
     (api.post as unknown as Mock).mockReset();
     (api.put as unknown as Mock).mockReset();
+    (api.get as unknown as Mock).mockReset();
     (Notify.create as unknown as Mock).mockReset();
   });
 
   it('sends formdata and notifies success', async () => {
-    (api.post as unknown as Mock).mockResolvedValueOnce({});
+    (api.post as unknown as Mock).mockResolvedValueOnce({ status: 201 });
+    (api.get as unknown as Mock).mockResolvedValueOnce({ data: [] });
     const store = useProductsStore();
     const file = new File(['hello'], 'img.png', { type: 'image/png' });
     await store.save(
       {
         name: 'Test',
-        priceCents: 100,
+        description: 'desc',
+        price: 1,
         stock: 5,
         category: 'cat',
         status: 'ACTIVE' as const,
@@ -50,21 +54,25 @@ describe('products store formdata', () => {
   });
 
   it('notifies error on failure', async () => {
-    (api.post as unknown as Mock).mockRejectedValueOnce({ response: { status: 500 } });
+    (api.post as unknown as Mock).mockRejectedValueOnce({ response: { status: 400, data: { message: 'Bad' } } });
+    (api.get as unknown as Mock).mockResolvedValueOnce({ data: [] });
     const store = useProductsStore();
-    await store.save(
-      {
-        name: 'Bad',
-        priceCents: 100,
-        stock: 5,
-        category: 'cat',
-        status: 'ACTIVE' as const,
-      },
-      [],
-    );
+    await expect(
+      store.save(
+        {
+          name: 'Bad',
+          description: 'd',
+          price: 1,
+          stock: 5,
+          category: 'cat',
+          status: 'ACTIVE' as const,
+        },
+        [],
+      ),
+    ).rejects.toBeDefined();
     expect(Notify.create).toHaveBeenCalledWith({
       type: 'negative',
-      message: 'Error inesperado, inténtalo de nuevo',
+      message: 'Bad',
     });
   });
 });

--- a/frontend/src/stores/products.ts
+++ b/frontend/src/stores/products.ts
@@ -7,6 +7,7 @@ import { Notify } from 'quasar';
 type AdminProduct = Partial<Product> & {
   category?: string;
   status?: 'ACTIVE' | 'INACTIVE';
+  price?: number;
 };
 
 export const useProductsStore = defineStore('adminProducts', {
@@ -34,36 +35,43 @@ export const useProductsStore = defineStore('adminProducts', {
     async save(product: AdminProduct, images: File[]) {
       const auth = useAuthStore();
       const form = new FormData();
-      const { id, name, priceCents, stock, category, status, description } = product;
+      const { id, name, price, priceCents, stock, category, status, description } = product;
       if (name != null) form.append('name', String(name));
       if (description != null) form.append('description', String(description));
-      if (priceCents != null) form.append('priceCents', String(priceCents));
+      if (price != null) {
+        form.append('priceCents', String(Math.round(Number(price) * 100)));
+      } else if (priceCents != null) {
+        form.append('priceCents', String(priceCents));
+      }
       if (stock != null) form.append('stock', String(stock));
       if (category != null) form.append('category', String(category));
       if (status != null) form.append('status', String(status));
       images.forEach((img) => form.append('images', img));
       try {
+        let resp;
         if (id) {
-          await api.put(`/api/admin/products/${id}`, form, {
+          resp = await api.put(`/api/admin/products/${id}`, form, {
             headers: { Authorization: `Bearer ${auth.token}` },
           });
         } else {
-          await api.post('/api/admin/products', form, {
+          resp = await api.post('/api/admin/products', form, {
             headers: { Authorization: `Bearer ${auth.token}` },
           });
         }
-        Notify.create({ type: 'positive', message: 'Producto guardado' });
-        await this.fetch();
+        if (resp.status === 200 || resp.status === 201) {
+          Notify.create({ type: 'positive', message: 'Producto guardado' });
+          await this.fetch();
+        }
       } catch (err: unknown) {
-        const e = err as { response?: { status?: number } };
+        const e = err as { response?: { status?: number; data?: { message?: string } } };
         const status = e.response?.status;
-        Notify.create({
-          type: 'negative',
-          message:
-            status === 401 || status === 403
-              ? 'No autorizado, inicia sesión como admin'
-              : 'Error inesperado, inténtalo de nuevo',
-        });
+        const message =
+          e.response?.data?.message ||
+          (status === 401 || status === 403
+            ? 'No autorizado, inicia sesión como admin'
+            : 'Error inesperado, inténtalo de nuevo');
+        Notify.create({ type: 'negative', message });
+        throw err;
       }
     },
     async updateStock(id: number, stock: number) {


### PR DESCRIPTION
## Summary
- Ensure product creation fills missing fields with defaults and auto-generates unique slugs
- Add description and price validation in admin product form
- Improve product store notifications and price conversion

## Testing
- `npm test -w backend`
- `npm test -w frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b5f1bad6008325a98800359491c470