### PR TITLE
feat: allow checkout without zone

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -12,7 +12,11 @@ import { authenticate } from '../middleware/auth.js';
 const createOrderSchema = z.object({
   email: z.string().email().optional(),
   couponId: z.number().int().optional(),
-  zone: z.string().min(1),
+  // zone is optional; if missing or empty, default to "default"
+  zone: z
+    .string()
+    .optional()
+    .transform((val) => (val && val.trim() !== '' ? val : 'default')),
   items: z
     .array(
       z.object({
@@ -63,7 +67,8 @@ export function createOrdersRouter(
   router.post('/create-order', async (req, res, next) => {
     const parsed = createOrderSchema.safeParse(req.body);
     if (!parsed.success) {
-      return res.status(400).json({ error: parsed.error.flatten() });
+      const message = parsed.error.issues.map((i) => i.message).join(', ');
+      return res.status(400).json({ error: message });
     }
 
     const { items, email, couponId, zone } = parsed.data;
@@ -148,7 +153,8 @@ export function createOrdersRouter(
 
       res.json({ orderId: order.id, totalCents: order.totalCents });
     } catch (err) {
-      next(err);
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      res.status(500).json({ error: message });
     }
   });
 

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -21,7 +21,12 @@ class FakePrisma {
   products = [{ id: 1, priceCents: 1000, stock: 5 }];
   orders: any[] = [];
   events: any[] = [];
-  shippingRates = [{ zone: 'NORTE', minWeight: 1, maxWeight: 10, priceCents: 0 }];
+  shippingRates = [
+    { zone: 'NORTE', minWeight: 1, maxWeight: 10, priceCents: 0 },
+    { zone: 'default', minWeight: 1, maxWeight: 10, priceCents: 0 },
+  ];
+
+  lastShippingZone?: string;
 
   product = {
     findMany: async ({ where }: any) => {
@@ -39,6 +44,7 @@ class FakePrisma {
 
   shippingRate = {
     findFirst: async ({ where }: any) => {
+      this.lastShippingZone = where.zone;
       return this.shippingRates.find((r) => r.zone === where.zone) || null;
     },
   };
@@ -81,6 +87,16 @@ beforeEach(() => {
 });
 
 describe('orders', () => {
+  it('creates order with default zone when none provided', async () => {
+    await request(app)
+      .post('/api/orders/create-order')
+      .send({ items: [{ productId: 1, quantity: 1 }] })
+      .expect(200);
+
+    expect(prisma.orders[0]).toBeTruthy();
+    expect(prisma.lastShippingZone).toBe('default');
+  });
+
   it('creates order and confirms via webhook', async () => {
     const createRes = await request(app)
       .post('/api/orders/create-order')


### PR DESCRIPTION
## Summary
- make `zone` optional in checkout and default to "default" when missing
- return validation and server error messages to the client
- test default shipping zone behavior

## Testing
- ⚠️ `npm test` (frontend store tests require browser APIs)
- ✅ `npx vitest run tests/auth.test.ts tests/orders.test.ts tests/products.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5fd9a952083259891137b77fd1421