### PR TITLE
Handle default shipping zone without rate

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -102,10 +102,15 @@ export function createOrdersRouter(
           maxWeight: { gte: weight },
         },
       });
+      let shippingCents = 0;
       if (!rate) {
-        return res.status(400).json({ error: 'Invalid shipping zone' });
+        if (zone !== 'default') {
+          return res.status(400).json({ error: 'Invalid shipping zone' });
+        }
+        shippingCents = 0;
+      } else {
+        shippingCents = rate.priceCents;
       }
-      const shippingCents = rate.priceCents;
 
       let discount = 0;
       if (couponId) {
@@ -151,7 +156,12 @@ export function createOrdersRouter(
         });
       }
 
-      res.json({ orderId: order.id, totalCents: order.totalCents });
+      res.json({
+        orderId: order.id,
+        totalCents: order.totalCents,
+        zone,
+        shipping_cents: shippingCents,
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
       res.status(500).json({ error: message });

--- a/backend/test/checkout.integration.test.ts
+++ b/backend/test/checkout.integration.test.ts
@@ -117,6 +117,27 @@ describe('checkout create-order', () => {
       .expect(400);
     expect(prisma.createdOrder).toBeNull();
   });
+
+  it('creates an order with default zone and zero shipping when rate missing', async () => {
+    const res = await request(app)
+      .post('/checkout/create-order')
+      .send({ items: [{ productId: 1, quantity: 1 }] })
+      .expect(200);
+
+    expect(res.body.zone).toBe('default');
+    expect(res.body.shipping_cents).toBe(0);
+    expect(prisma.createdOrder.shipping_cents).toBe(0);
+  });
+
+  it('returns 400 for invalid non-default zone', async () => {
+    const res = await request(app)
+      .post('/checkout/create-order')
+      .send({ items: [{ productId: 1, quantity: 1 }], zone: 'SUR' })
+      .expect(400);
+
+    expect(res.body).toEqual({ error: 'Invalid shipping zone' });
+    expect(prisma.createdOrder).toBeNull();
+  });
 });
 
 describe('checkout create-preference', () => {


### PR DESCRIPTION
## Summary
- allow checkout orders to use `default` zone even if no shipping rate exists
- include `zone` and `shipping_cents` in order creation response
- add tests for default and invalid shipping zones

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6088969408325be8dc2b8f59b4132