### PR TITLE
fix: remove currency field when creating order

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -124,7 +124,6 @@ export function createOrdersRouter(
       const order = await prisma.order.create({
         data: {
           status: 'PENDING',
-          currency: 'MXN',
           totalCents: total - discount + shippingCents,
           shipping_cents: shippingCents,
           items: {


### PR DESCRIPTION
## Summary
- remove currency field from order creation to match Prisma schema

## Testing
- `npx vitest run tests/orders.test.ts`
- `npx vitest run tests/checkout.integration.test.ts` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b60b867c6c8325a2b957c86a3d94e9