### PR TITLE
Improve MercadoPago preference creation

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -168,11 +168,28 @@ export function createOrdersRouter(
   });
 
   router.post('/create-preference', async (req, res) => {
-    const items = req.body as Array<{ title: string; quantity: number; unit_price: number }>;
+    req.log?.info({ body: req.body }, 'Received create-preference body');
+
+    let items: Array<{ title: string; quantity: number; unit_price: number; currency_id?: string }> = [];
+
+    if (Array.isArray(req.body)) {
+      items = req.body;
+    } else if (Array.isArray(req.body.items)) {
+      items = req.body.items;
+    } else if (req.body?.preference && Array.isArray(req.body.preference.items)) {
+      items = req.body.preference.items;
+    }
 
     if (!Array.isArray(items) || items.length === 0) {
-      return res.status(400).json({ success: false, error: 'No items provided' });
+      return res.status(400).json({ success: false, message: 'No items provided' });
     }
+
+    const normalizedItems = items.map((item) => ({
+      ...item,
+      currency_id: item.currency_id ?? 'MXN',
+    }));
+
+    req.log?.info({ items: normalizedItems }, 'Items to send to MercadoPago');
 
     try {
       const mp = new MercadoPagoConfig({
@@ -181,7 +198,7 @@ export function createOrdersRouter(
 
       const preference = await new Preference(mp).create({
         body: {
-          items,
+          items: normalizedItems,
           back_urls: {
             success: 'http://localhost:9000/success',
             failure: 'http://localhost:9000/failure',
@@ -190,15 +207,23 @@ export function createOrdersRouter(
         },
       });
 
+      req.log?.info({ preference }, 'MercadoPago preference response');
+
       return res.json({
         success: true,
-        preferenceId: preference.id,
-        init_point: preference.init_point,
+        id: preference.id,
+        items: normalizedItems,
       });
-    } catch {
-      return res
-        .status(500)
-        .json({ success: false, error: 'Error creando preferencia' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const stack = err instanceof Error ? err.stack : undefined;
+      req.log?.error({ err }, 'Error creating MercadoPago preference');
+      return res.status(500).json({
+        success: false,
+        message: 'Error creando preferencia',
+        error: message,
+        stack,
+      });
     }
   });
 

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -10,10 +10,15 @@ process.env.JWT_SECRET = 'testsecret';
 
 let createApp: typeof import('../backend/src/app.js').createApp;
 
+const preferenceCreateMock = vi.fn().mockImplementation(async ({ body }: any) => ({ id: 'pref_test', ...body }));
+
 vi.mock('mercadopago', () => ({
   MercadoPagoConfig: vi.fn().mockImplementation(() => ({})),
   Payment: vi.fn().mockImplementation(() => ({
     get: vi.fn(),
+  })),
+  Preference: vi.fn().mockImplementation(() => ({
+    create: preferenceCreateMock,
   })),
 }));
 
@@ -84,6 +89,7 @@ beforeEach(() => {
   prisma = new FakePrisma();
   app = createApp(prisma as unknown as PrismaClient);
   app.set('trust proxy', 'loopback');
+  preferenceCreateMock.mockClear();
 });
 
 describe('orders', () => {
@@ -113,5 +119,29 @@ describe('orders', () => {
 
     expect(prisma.orders[0].status).toBe('CONFIRMED');
     expect(prisma.products[0].stock).toBe(4);
+  });
+});
+
+describe('checkout create-preference', () => {
+  it('accepts payload with items property', async () => {
+    const res = await request(app)
+      .post('/checkout/create-preference')
+      .send({ items: [{ title: 'Item 1', quantity: 1, unit_price: 10, currency_id: 'USD' }] })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.items[0].currency_id).toBe('USD');
+    expect(res.body.id).toBe('pref_test');
+  });
+
+  it('accepts array payload and defaults currency_id to MXN', async () => {
+    const res = await request(app)
+      .post('/checkout/create-preference')
+      .send([{ title: 'Item 2', quantity: 2, unit_price: 20 }])
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.items[0].currency_id).toBe('MXN');
+    expect(res.body.id).toBe('pref_test');
   });
 });


### PR DESCRIPTION
## Summary
- Handle multiple payload formats for MercadoPago preference creation and enforce MXN as default currency
- Add detailed logging and robust error handling for /checkout/create-preference
- Add integration tests for payload variations and currency normalization

## Testing
- `npm test` *(fails: ReferenceError localStorage is not defined)*
- `npx vitest run tests/orders.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b6115d92248325b572cb2f8134a2e6