### PR TITLE
feat: mock checkout payments

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -145,6 +145,7 @@ enum Role {
 
 enum OrderStatus {
   PENDING
+  PAID
   CONFIRMED
   SHIPPED
   CANCELLED

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -123,7 +123,7 @@ export function createOrdersRouter(
 
       const order = await prisma.order.create({
         data: {
-          status: 'PENDING',
+          status: 'PAID',
           totalCents: total - discount + shippingCents,
           shipping_cents: shippingCents,
           items: {
@@ -156,14 +156,15 @@ export function createOrdersRouter(
       }
 
       res.json({
+        success: true,
         orderId: order.id,
+        status: order.status,
         totalCents: order.totalCents,
-        zone,
-        shipping_cents: shippingCents,
       });
     } catch (err) {
+      console.error(err);
       const message = err instanceof Error ? err.message : 'Unknown error';
-      res.status(500).json({ error: message });
+      res.status(500).json({ success: false, error: message });
     }
   });
 

--- a/backend/test/checkout.integration.test.ts
+++ b/backend/test/checkout.integration.test.ts
@@ -20,14 +20,14 @@ vi.mock('mercadopago', () => ({
 
 interface Product {
   id: number;
-  price_cents: number;
+  priceCents: number;
   stock: number;
 }
 
 class FakePrisma {
   products: Product[] = [
-    { id: 1, price_cents: 10000, stock: 3 },
-    { id: 5, price_cents: 59900, stock: 1 },
+    { id: 1, priceCents: 10000, stock: 3 },
+    { id: 5, priceCents: 59900, stock: 1 },
   ];
 
   createdOrder: any = null;
@@ -99,8 +99,13 @@ describe('checkout create-order', () => {
       })
       .expect(200);
 
-    expect(res.body.totalCents).toBe(80400);
-    expect(prisma.createdOrder.status).toBe('PENDING');
+    expect(res.body).toEqual({
+      success: true,
+      orderId: 123,
+      status: 'PAID',
+      totalCents: 80400,
+    });
+    expect(prisma.createdOrder.status).toBe('PAID');
     expect(prisma.createdOrder.currency).toBe('MXN');
     expect(prisma.createdOrder.totalCents).toBe(80400);
     expect(prisma.createdOrder.shipping_cents).toBe(500);
@@ -124,8 +129,13 @@ describe('checkout create-order', () => {
       .send({ items: [{ productId: 1, quantity: 1 }] })
       .expect(200);
 
-    expect(res.body.zone).toBe('default');
-    expect(res.body.shipping_cents).toBe(0);
+    expect(res.body).toEqual({
+      success: true,
+      orderId: 123,
+      status: 'PAID',
+      totalCents: 10000,
+    });
+    expect(prisma.createdOrder.status).toBe('PAID');
     expect(prisma.createdOrder.shipping_cents).toBe(0);
   });
 

--- a/frontend/src/pages/AdminOrdersPage.vue
+++ b/frontend/src/pages/AdminOrdersPage.vue
@@ -18,7 +18,7 @@ import axios from 'axios';
 
 const $q = useQuasar();
 const ordersStore = useOrdersStore();
-const statuses = ['PENDING','CONFIRMED','SHIPPED','CANCELLED'];
+const statuses = ['PAID', 'PENDING','CONFIRMED','SHIPPED','CANCELLED'];
 const columns = [
   { name: 'id', label: 'ID', field: 'id' },
   { name: 'status', label: 'Estado', field: 'status' },

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -70,17 +70,12 @@ async function pay() {
       }),
     });
     if (!orderRes.ok) throw new Error('Error creando orden');
-    const { orderId } = await orderRes.json();
-
-    const prefRes = await fetch('/api/checkout/create-preference', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orderId }),
+    const data = await orderRes.json();
+    if (!data.success) throw new Error('Pago no procesado');
+    $q.notify({
+      type: 'positive',
+      message: `Orden #${data.orderId} pagada correctamente`,
     });
-    if (!prefRes.ok) throw new Error('Error creando preferencia');
-    const { init_point } = await prefRes.json();
-    if (!init_point) throw new Error('init_point vacío');
-    window.location.href = init_point;
   } catch (err) {
     $q.notify({ type: 'negative', message: (err as Error).message });
   }

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -113,15 +113,12 @@ async function pay() {
       }),
     });
     if (!orderRes.ok) throw new Error('Error creando orden');
-    const { orderId } = await orderRes.json();
-    const prefRes = await fetch(`${apiBase}/checkout/create-preference`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orderId }),
+    const data = await orderRes.json();
+    if (!data.success) throw new Error('Pago no procesado');
+    $q.notify({
+      type: 'positive',
+      message: `Orden #${data.orderId} pagada correctamente`,
     });
-    if (!prefRes.ok) throw new Error('Error creando preferencia');
-    const { init_point } = await prefRes.json();
-    window.location.href = init_point;
   } catch (err) {
     $q.notify({ type: 'negative', message: (err as Error).message });
   }

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -94,31 +94,29 @@ beforeEach(() => {
 
 describe('orders', () => {
   it('creates order with default zone when none provided', async () => {
-    await request(app)
+    const res = await request(app)
       .post('/api/orders/create-order')
       .send({ items: [{ productId: 1, quantity: 1 }] })
       .expect(200);
 
+    expect(res.body).toEqual({
+      success: true,
+      orderId: 1,
+      status: 'PAID',
+      totalCents: 1000,
+    });
     expect(prisma.orders[0]).toBeTruthy();
+    expect(prisma.orders[0].status).toBe('PAID');
     expect(prisma.lastShippingZone).toBe('default');
   });
 
-  it('creates order and confirms via webhook', async () => {
+  it('creates order with status PAID', async () => {
     const createRes = await request(app)
       .post('/api/orders/create-order')
       .send({ items: [{ productId: 1, quantity: 1 }], zone: 'NORTE' })
       .expect(200);
-    const orderId = createRes.body.orderId;
-    expect(prisma.orders[0].status).toBe('PENDING');
-
-    await request(app)
-      .post('/webhook/mercadopago')
-      .set('X-Forwarded-For', '1.1.1.1')
-      .send({ id: 'evt1', mp_payment_id: 'pay1', orderId, payment_status: 'approved' })
-      .expect(200);
-
-    expect(prisma.orders[0].status).toBe('CONFIRMED');
-    expect(prisma.products[0].stock).toBe(4);
+    expect(createRes.body.status).toBe('PAID');
+    expect(prisma.orders[0].status).toBe('PAID');
   });
 });
 


### PR DESCRIPTION
## Summary
- mark new orders as paid and return success payload
- call checkout/create-order directly from cart and checkout
- show paid orders in admin

## Testing
- `npm run db:generate -w backend`
- `npm test -w backend`
- `npm test -w frontend`
- `npx vitest run tests/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b61e0115e48325a2d4348869453c3e