### PR TITLE
feat: clear cart after checkout

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { z } from 'zod';
 // eslint-disable-next-line import/no-unresolved
 import { MercadoPagoConfig, Preference } from 'mercadopago';
+import jwt from 'jsonwebtoken';
 import type { PrismaClient, User } from '@prisma/client';
 import type { Counter } from 'prom-client';
 // eslint-disable-next-line import/no-unresolved
@@ -72,6 +73,22 @@ export function createOrdersRouter(
     }
 
     const { items, email, couponId, zone } = parsed.data;
+    const authHeader = req.get('authorization');
+    let userId: number | null = null;
+    if (authHeader?.startsWith('Bearer ')) {
+      try {
+        const token = authHeader.replace('Bearer ', '');
+        const payload = jwt.verify(
+          token,
+          process.env.JWT_SECRET || '',
+        ) as jwt.JwtPayload;
+        if (payload.sub) {
+          userId = Number(payload.sub);
+        }
+      } catch {
+        userId = null;
+      }
+    }
     try {
       const ids = items.map((i) => i.productId);
       const products = await prisma.product.findMany({
@@ -155,11 +172,25 @@ export function createOrdersRouter(
         });
       }
 
+      let cartCleared = false;
+      if (userId) {
+        try {
+          const cart = await prisma.cart.findFirst({ where: { userId } });
+          if (cart) {
+            await prisma.cartItem.deleteMany({ where: { cartId: cart.id } });
+            cartCleared = true;
+          }
+        } catch (clearErr) {
+          console.error('Error clearing cart:', clearErr);
+        }
+      }
+
       res.json({
         success: true,
         orderId: order.id,
         status: order.status,
         totalCents: order.totalCents,
+        cartCleared,
       });
     } catch (err) {
       console.error(err);

--- a/backend/test/checkout.integration.test.ts
+++ b/backend/test/checkout.integration.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
+import jwt from 'jsonwebtoken';
 import type { PrismaClient } from '@prisma/client';
 
 let createApp: typeof import('../src/app.js').createApp;
@@ -38,6 +39,10 @@ class FakePrisma {
     { zone: 'NORTE', minWeight: 1, maxWeight: 10, priceCents: 500 },
   ];
 
+  carts: Array<{ id: number; userId: number; items: Array<{ id: number }>; }> = [
+    { id: 1, userId: 1, items: [{ id: 10 }] },
+  ];
+
   product = {
     findMany: async ({ where }: any) => {
       const ids: number[] = where.id.in;
@@ -53,6 +58,18 @@ class FakePrisma {
           (r) => r.zone === where.zone && r.minWeight <= weight && r.maxWeight >= weight,
         ) || null
       );
+    },
+  };
+
+  cart = {
+    findFirst: async ({ where }: any) =>
+      this.carts.find((c) => c.userId === where.userId) || null,
+  };
+
+  cartItem = {
+    deleteMany: async ({ where }: any) => {
+      const cart = this.carts.find((c) => c.id === where.cartId);
+      if (cart) cart.items = [];
     },
   };
 
@@ -134,6 +151,7 @@ describe('checkout create-order', () => {
       orderId: 123,
       status: 'PAID',
       totalCents: 10000,
+      cartCleared: false,
     });
     expect(prisma.createdOrder.status).toBe('PAID');
     expect(prisma.createdOrder.shipping_cents).toBe(0);
@@ -147,6 +165,18 @@ describe('checkout create-order', () => {
 
     expect(res.body).toEqual({ error: 'Invalid shipping zone' });
     expect(prisma.createdOrder).toBeNull();
+  });
+
+  it('clears cart after order creation when authenticated', async () => {
+    const token = jwt.sign({ sub: 1 }, process.env.JWT_SECRET || '');
+    const res = await request(app)
+      .post('/checkout/create-order')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ items: [{ productId: 1, quantity: 1 }] })
+      .expect(200);
+
+    expect(res.body.cartCleared).toBe(true);
+    expect(prisma.carts[0].items).toHaveLength(0);
   });
 });
 

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -51,9 +51,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useCartStore } from 'stores/cart';
+import { useAuthStore } from 'stores/auth';
 import { useQuasar } from 'quasar';
 
 const cartStore = useCartStore();
+const auth = useAuthStore();
 const cart = computed(() => cartStore.cart);
 const subtotal = computed(() => cartStore.subtotal);
 const total = computed(() => cartStore.total);
@@ -62,9 +64,13 @@ const $q = useQuasar();
 
 async function pay() {
   try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (auth.token) {
+      headers.Authorization = `Bearer ${auth.token}`;
+    }
     const orderRes = await fetch('/api/checkout/create-order', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({
         items: cart.value.map((l) => ({ productId: l.productId, quantity: l.qty })),
       }),
@@ -72,6 +78,9 @@ async function pay() {
     if (!orderRes.ok) throw new Error('Error creando orden');
     const data = await orderRes.json();
     if (!data.success) throw new Error('Pago no procesado');
+    if (data.cartCleared) {
+      cartStore.cart = [];
+    }
     $q.notify({
       type: 'positive',
       message: `Orden #${data.orderId} pagada correctamente`,

--- a/tests/orders.test.ts
+++ b/tests/orders.test.ts
@@ -104,6 +104,7 @@ describe('orders', () => {
       orderId: 1,
       status: 'PAID',
       totalCents: 1000,
+      cartCleared: false,
     });
     expect(prisma.orders[0]).toBeTruthy();
     expect(prisma.orders[0].status).toBe('PAID');


### PR DESCRIPTION
## Summary
- empty user cart after a paid order is created
- send auth token during checkout and reset cart store when cleared
- test that cart items are removed once an order is placed

## Testing
- `npm test -w backend`
- `npm test -w frontend`
- `npm test` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b62820c9b0832592a9add6f7f54a5b