### PR TITLE
feat: allow cancelling orders and clear cart

### DIFF
--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -199,6 +199,72 @@ export function createOrdersRouter(
     }
   });
 
+  router.post('/cancel-order', async (req, res) => {
+    const parsed = z
+      .object({ orderId: z.number().int().positive() })
+      .safeParse(req.body);
+    if (!parsed.success) {
+      const message = parsed.error.issues.map((i) => i.message).join(', ');
+      return res.status(400).json({ error: message });
+    }
+    const { orderId } = parsed.data;
+
+    const authHeader = req.get('authorization');
+    let userId: number | null = null;
+    if (authHeader?.startsWith('Bearer ')) {
+      try {
+        const token = authHeader.replace('Bearer ', '');
+        const payload = jwt.verify(
+          token,
+          process.env.JWT_SECRET || '',
+        ) as jwt.JwtPayload;
+        if (payload.sub) {
+          userId = Number(payload.sub);
+        }
+      } catch {
+        userId = null;
+      }
+    }
+
+    try {
+      const order = await prisma.order.findUnique({ where: { id: orderId } });
+      if (!order || order.status !== 'PAID') {
+        return res
+          .status(404)
+          .json({ error: 'Order not found or cannot be cancelled' });
+      }
+
+      const updated = await prisma.order.update({
+        where: { id: orderId },
+        data: { status: 'CANCELLED' },
+      });
+
+      let cartCleared = false;
+      if (userId) {
+        try {
+          const cart = await prisma.cart.findFirst({ where: { userId } });
+          if (cart) {
+            await prisma.cartItem.deleteMany({ where: { cartId: cart.id } });
+            cartCleared = true;
+          }
+        } catch (clearErr) {
+          console.error('Error clearing cart:', clearErr);
+        }
+      }
+
+      return res.json({
+        success: true,
+        orderId: updated.id,
+        status: updated.status,
+        cartCleared,
+      });
+    } catch (err) {
+      console.error(err);
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      return res.status(500).json({ success: false, error: message });
+    }
+  });
+
   router.post('/create-preference', async (req, res) => {
     console.log(
       '[DEBUG] Received body:',

--- a/backend/test/checkout.integration.test.ts
+++ b/backend/test/checkout.integration.test.ts
@@ -207,3 +207,28 @@ describe('checkout create-preference', () => {
     ]);
   });
 });
+
+describe('checkout cancel-order', () => {
+  it('cancels an order and clears cart when authenticated', async () => {
+    prisma.orderToFind = { id: 123, status: 'PAID' };
+    const token = jwt.sign({ sub: 1 }, process.env.JWT_SECRET || '');
+
+    const res = await request(app)
+      .post('/checkout/cancel-order')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ orderId: 123 })
+      .expect(200);
+
+    expect(res.body).toEqual({
+      success: true,
+      orderId: 123,
+      status: 'CANCELLED',
+      cartCleared: true,
+    });
+    expect(prisma.updatedOrder).toEqual({
+      where: { id: 123 },
+      data: { status: 'CANCELLED' },
+    });
+    expect(prisma.carts[0].items).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -42,7 +42,10 @@
           Total: {{ (total / 100).toFixed(2) }}
           {{ currency }}
         </div>
-        <q-btn color="primary" label="Pagar" class="q-mt-md" @click="async () => { await pay(); }" />
+        <div class="q-mt-md">
+          <q-btn color="primary" label="Pagar" @click="async () => { await pay(); }" />
+          <q-btn color="negative" label="Cancelar" class="q-ml-sm" @click="async () => { await cancelOrder(); }" />
+        </div>
       </div>
     </div>
   </q-page>
@@ -85,6 +88,32 @@ async function pay() {
       type: 'positive',
       message: `Orden #${data.orderId} pagada correctamente`,
     });
+  } catch (err) {
+    $q.notify({ type: 'negative', message: (err as Error).message });
+  }
+}
+
+async function cancelOrder() {
+  try {
+    const input = prompt('ID de la orden a cancelar');
+    if (!input) return;
+    const orderId = Number(input);
+    if (Number.isNaN(orderId)) throw new Error('ID de orden inválido');
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (auth.token) {
+      headers.Authorization = `Bearer ${auth.token}`;
+    }
+    const res = await fetch('/api/checkout/cancel-order', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ orderId }),
+    });
+    if (!res.ok) throw new Error('Error cancelando orden');
+    const data = await res.json();
+    if (data.cartCleared) {
+      cartStore.cart = [];
+    }
+    $q.notify({ type: 'positive', message: 'Orden cancelada y carrito vaciado' });
   } catch (err) {
     $q.notify({ type: 'negative', message: (err as Error).message });
   }


### PR DESCRIPTION
## Summary
- add `POST /checkout/cancel-order` to cancel an order and empty cart
- add cancel button in cart page invoking new endpoint
- test order cancellation clears cart

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68b62a50ea308325a592dd79d4b817dd