### PR TITLE
feat: simplify order cancellation

### DIFF
--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -44,7 +44,12 @@
         </div>
         <div class="q-mt-md">
           <q-btn color="primary" label="Pagar" @click="async () => { await pay(); }" />
-          <q-btn color="negative" label="Cancelar" class="q-ml-sm" @click="async () => { await cancelOrder(); }" />
+          <q-btn
+            color="negative"
+            label="Cancelar"
+            class="q-ml-sm"
+            @click="cancelOrder"
+          />
         </div>
       </div>
     </div>
@@ -56,6 +61,7 @@ import { computed } from 'vue';
 import { useCartStore } from 'stores/cart';
 import { useAuthStore } from 'stores/auth';
 import { useQuasar } from 'quasar';
+import { api } from 'src/api/api';
 
 const cartStore = useCartStore();
 const auth = useAuthStore();
@@ -95,27 +101,17 @@ async function pay() {
 
 async function cancelOrder() {
   try {
-    const input = prompt('ID de la orden a cancelar');
-    if (!input) return;
-    const orderId = Number(input);
-    if (Number.isNaN(orderId)) throw new Error('ID de orden inválido');
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (auth.token) {
-      headers.Authorization = `Bearer ${auth.token}`;
-    }
-    const res = await fetch('/api/checkout/cancel-order', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ orderId }),
+    await api.post('/checkout/cancel-order');
+    cartStore.cart = [];
+    // @ts-ignore - mantener compatibilidad si existe `items`
+    cartStore.items = [];
+    $q.notify({
+      type: 'negative',
+      message: 'Orden cancelada y carrito vaciado',
     });
-    if (!res.ok) throw new Error('Error cancelando orden');
-    const data = await res.json();
-    if (data.cartCleared) {
-      cartStore.cart = [];
-    }
-    $q.notify({ type: 'positive', message: 'Orden cancelada y carrito vaciado' });
   } catch (err) {
-    $q.notify({ type: 'negative', message: (err as Error).message });
+    console.error(err);
+    $q.notify({ type: 'negative', message: 'Error al cancelar la orden' });
   }
 }
 </script>

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -48,9 +48,7 @@
           <q-btn
             label="Cancelar"
             color="negative"
-            @click="async () => {
-              await cancel();
-            }"
+            @click="cancelOrder"
           />
         </div>
       </div>
@@ -64,13 +62,12 @@ import { ref, computed } from 'vue';
 import { useCartStore } from 'stores/cart';
 import { useCouponStore } from 'stores/coupons';
 import { useShippingStore } from 'stores/shipping';
-import { useAuthStore } from 'stores/auth';
 import { useQuasar } from 'quasar';
+import { api } from 'src/api/api';
 
 const cartStore = useCartStore();
 const couponStore = useCouponStore();
 const shippingStore = useShippingStore();
-const auth = useAuthStore();
 const cart = computed(() => cartStore.cart);
 const subtotal = computed(() => cartStore.subtotal);
 const discount = computed(() => couponStore.coupon?.discount ?? 0);
@@ -135,25 +132,21 @@ async function pay() {
   }
 }
 
-async function cancel() {
+async function cancelOrder() {
   try {
-    const res = await fetch(`${apiBase}/checkout/cancel-order`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${auth.token}` },
-    });
-    const data = await res.json();
-    if (!res.ok || !data.success) {
-      throw new Error(data.message || 'Error cancelando orden');
-    }
+    await api.post('/checkout/cancel-order');
     cartStore.cart = [];
+    // @ts-ignore - mantener compatibilidad si existe `items`
+    cartStore.items = [];
     $q.notify({
-      type: 'positive',
+      type: 'negative',
       message: 'Orden cancelada y carrito vaciado',
     });
   } catch (err) {
+    console.error(err);
     $q.notify({
       type: 'negative',
-      message: (err as Error).message,
+      message: 'Error al cancelar la orden',
     });
   }
 }


### PR DESCRIPTION
## Summary
- remove order ID prompt and call `/checkout/cancel-order` directly
- clear cart and show cancellation notification on both Cart and Checkout pages

## Testing
- `npm test` *(fails: ReferenceError: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6308c2654832580c452a01ff5c01e