### PR TITLE
Remove cancel buttons from cart and checkout pages

### DIFF
--- a/frontend/src/pages/CartPage.vue
+++ b/frontend/src/pages/CartPage.vue
@@ -44,12 +44,6 @@
         </div>
         <div class="q-mt-md">
           <q-btn color="primary" label="Pagar" @click="async () => { await pay(); }" />
-          <q-btn
-            color="negative"
-            label="Cancelar"
-            class="q-ml-sm"
-            @click="cancelOrder"
-          />
         </div>
       </div>
     </div>
@@ -61,7 +55,6 @@ import { computed } from 'vue';
 import { useCartStore } from 'stores/cart';
 import { useAuthStore } from 'stores/auth';
 import { useQuasar } from 'quasar';
-import { api } from 'src/api/api';
 
 const cartStore = useCartStore();
 const auth = useAuthStore();
@@ -96,20 +89,6 @@ async function pay() {
     });
   } catch (err) {
     $q.notify({ type: 'negative', message: (err as Error).message });
-  }
-}
-
-async function cancelOrder() {
-  try {
-    await api.post('/checkout/cancel-order');
-    cartStore.items = [];
-    $q.notify({
-      type: 'negative',
-      message: 'Orden cancelada y carrito vaciado',
-    });
-  } catch (err) {
-    console.error(err);
-    $q.notify({ type: 'negative', message: 'Error al cancelar la orden' });
   }
 }
 </script>

--- a/frontend/src/pages/CheckoutPage.vue
+++ b/frontend/src/pages/CheckoutPage.vue
@@ -45,11 +45,6 @@
         </div>
         <div class="row q-mt-md q-gutter-sm">
           <CheckoutButton @click="async () => { await pay(); }" />
-          <q-btn
-            label="Cancelar"
-            color="negative"
-            @click="cancelOrder"
-          />
         </div>
       </div>
     </div>
@@ -63,7 +58,6 @@ import { useCartStore } from 'stores/cart';
 import { useCouponStore } from 'stores/coupons';
 import { useShippingStore } from 'stores/shipping';
 import { useQuasar } from 'quasar';
-import { api } from 'src/api/api';
 
 const cartStore = useCartStore();
 const couponStore = useCouponStore();
@@ -129,23 +123,6 @@ async function pay() {
     });
   } catch (err) {
     $q.notify({ type: 'negative', message: (err as Error).message });
-  }
-}
-
-async function cancelOrder() {
-  try {
-    await api.post('/checkout/cancel-order');
-    cartStore.items = [];
-    $q.notify({
-      type: 'negative',
-      message: 'Orden cancelada y carrito vaciado',
-    });
-  } catch (err) {
-    console.error(err);
-    $q.notify({
-      type: 'negative',
-      message: 'Error al cancelar la orden',
-    });
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- remove cancel button and logic from cart page
- remove cancel button and logic from checkout page

## Testing
- `npm test` *(fails: ReferenceError: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b6361977c483259d2a219bf3dd663d